### PR TITLE
Added support for declaring and deleting bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,36 @@ resp, err := rmqc.DeleteQueue("/", "a.queue")
 
 ### Operations on Bindings
 
-TBD
+``` go
+bs, err := rmqc.ListBindings()
+// => []BindingInfo, err
 
+// list bindings in a vhost
+bs, err := rmqc.ListBindingsIn("/")
+// => []BindingInfo, err
+
+// list bindings of a queue 
+bs, err := rmqc.ListQueueBindings("/", "a.queue")
+// => []BindingInfo, err
+
+// declare a binding
+resp, err := rmqc.DeclareBinding("/", "a.binding", BindingInfo{
+	Source: "an.exchange", 
+	Destination: "a.queue", 
+	DestinationType: "queue", 
+	RoutingKey: "#",
+})
+// => *http.Response, err
+
+// deletes individual binding
+resp, err := rmqc.DeleteBinding("/", "a.binding", BindingInfo{
+	Source: "an.exchange", 
+	Destination: "a.queue", 
+	DestinationType: "queue", 
+	RoutingKey: "#",
+})
+// => *http.Response, err
+```
 
 ### HTTPS Connections
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ bs, err := rmqc.ListQueueBindings("/", "a.queue")
 // => []BindingInfo, err
 
 // declare a binding
-resp, err := rmqc.DeclareBinding("/", "a.binding", BindingInfo{
+resp, err := rmqc.DeclareBinding("/", BindingInfo{
 	Source: "an.exchange", 
 	Destination: "a.queue", 
 	DestinationType: "queue", 
@@ -231,11 +231,12 @@ resp, err := rmqc.DeclareBinding("/", "a.binding", BindingInfo{
 // => *http.Response, err
 
 // deletes individual binding
-resp, err := rmqc.DeleteBinding("/", "a.binding", BindingInfo{
+resp, err := rmqc.DeleteBinding("/", BindingInfo{
 	Source: "an.exchange", 
 	Destination: "a.queue", 
 	DestinationType: "queue", 
 	RoutingKey: "#",
+	PropertiesKey: "%23",
 })
 // => *http.Response, err
 ```

--- a/bindings.go
+++ b/bindings.go
@@ -108,7 +108,7 @@ func (c *Client) ListQueueBindings(vhost, queue string) (rec []BindingInfo, err 
 }
 
 //
-// POST /api/bindings/{vhost}/e/{exchange}/{destination_type}/{destination}
+// POST /api/bindings/{vhost}/e/{source}/{destination_type}/{destination}
 //
 
 // DeclareBinding updates information about a binding between a source and a target
@@ -138,7 +138,7 @@ func (c *Client) DeclareBinding(vhost string, info BindingInfo) (res *http.Respo
 }
 
 //
-// DELETE /api/bindings/{vhost}/e/{source}/{destination_type}/{destination}/{routing_key}
+// DELETE /api/bindings/{vhost}/e/{source}/{destination_type}/{destination}/{props}
 //
 
 // DeleteBinding delets an individual binding

--- a/bindings.go
+++ b/bindings.go
@@ -1,6 +1,8 @@
 package rabbithole
 
 import (
+	"encoding/json"
+	"net/http"
 	"net/url"
 )
 
@@ -103,4 +105,53 @@ func (c *Client) ListQueueBindings(vhost, queue string) (rec []BindingInfo, err 
 	}
 
 	return rec, nil
+}
+
+//
+// POST /api/bindings/{vhost}/e/{exchange}/{destination_type}/{destination}
+//
+
+// DeclareBinding updates information about a binding between a source and a target
+func (c *Client) DeclareBinding(vhost string, info BindingInfo) (res *http.Response, err error) {
+	info.Vhost = vhost
+
+	if info.Arguments == nil {
+		info.Arguments = make(map[string]interface{})
+	}
+	body, err := json.Marshal(info)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := newRequestWithBody(c, "POST", "bindings/"+url.QueryEscape(vhost)+"/e/"+url.QueryEscape(info.Source)+"/"+url.QueryEscape(string(info.DestinationType[0]))+"/"+url.QueryEscape(info.Destination), body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	res, err = executeRequest(c, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+//
+// DELETE /api/bindings/{vhost}/e/{source}/{destination_type}/{destination}/{routing_key}
+//
+
+// DeleteBinding delets an individual binding
+func (c *Client) DeleteBinding(vhost string, info BindingInfo) (res *http.Response, err error) {
+	req, err := newRequestWithBody(c, "DELETE", "bindings/"+url.QueryEscape(vhost)+"/e/"+url.QueryEscape(info.Source)+"/"+url.QueryEscape(string(info.DestinationType[0]))+"/"+url.QueryEscape(info.Destination)+"/"+url.QueryEscape(info.PropertiesKey), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err = executeRequest(c, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }

--- a/doc.go
+++ b/doc.go
@@ -83,6 +83,37 @@ Operations on Queues
         resp, err := rmqc.DeleteQueue("/", "a.queue")
         // => *http.Response, err
 
+Operations on Bindings
+
+        bs, err := rmqc.ListBindings()
+        // => []BindingInfo, err
+
+        // list bindings in a vhost
+        bs, err := rmqc.ListBindingsIn("/")
+        // => []BindingInfo, err
+
+        // list bindings of a queue
+        bs, err := rmqc.ListQueueBindings("/", "a.queue")
+        // => []BindingInfo, err
+
+        // declare a binding
+        resp, err := rmqc.DeclareBinding("/", "a.binding", BindingInfo{
+            Source: "an.exchange",
+            Destination: "a.queue",
+            DestinationType: "queue",
+            RoutingKey: "#",
+        })
+        // => *http.Response, err
+
+        // deletes individual binding
+        resp, err := rmqc.DeleteBinding("/", "a.binding", BindingInfo{
+            Source: "an.exchange",
+            Destination: "a.queue",
+            DestinationType: "queue",
+            RoutingKey: "#",
+        })
+        // => *http.Response, err
+
 Operations on Vhosts
 
         xs, err := rmqc.ListVhosts()

--- a/doc.go
+++ b/doc.go
@@ -97,7 +97,7 @@ Operations on Bindings
         // => []BindingInfo, err
 
         // declare a binding
-        resp, err := rmqc.DeclareBinding("/", "a.binding", BindingInfo{
+        resp, err := rmqc.DeclareBinding("/", BindingInfo{
             Source: "an.exchange",
             Destination: "a.queue",
             DestinationType: "queue",
@@ -106,11 +106,12 @@ Operations on Bindings
         // => *http.Response, err
 
         // deletes individual binding
-        resp, err := rmqc.DeleteBinding("/", "a.binding", BindingInfo{
+        resp, err := rmqc.DeleteBinding("/", BindingInfo{
             Source: "an.exchange",
             Destination: "a.queue",
             DestinationType: "queue",
             RoutingKey: "#",
+            PropertiesKey: "%23",
         })
         // => *http.Response, err
 

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -155,7 +155,6 @@ var _ = Describe("Rabbithole", func() {
 
 			Ω(res.MemUsed).Should(BeNumerically(">", 10*1024*1024))
 			Ω(res.MemLimit).Should(BeNumerically(">", 64*1024*1024))
-			Ω(res.MemAlarm).Should(Equal(false))
 
 			Ω(res.IsRunning).Should(Equal(true))
 
@@ -181,7 +180,6 @@ var _ = Describe("Rabbithole", func() {
 
 			Ω(res.MemUsed).Should(BeNumerically(">", 10*1024*1024))
 			Ω(res.MemLimit).Should(BeNumerically(">", 64*1024*1024))
-			Ω(res.MemAlarm).Should(Equal(false))
 
 			Ω(res.IsRunning).Should(Equal(true))
 


### PR DESCRIPTION
This closes #24 and closes #21.

This adds support for creating and removing Exchange-to-Exchange and Exchange-to-Queue bindings. Tests were added to cover adding and deleting bindings. When you add a binding, the response has a Location header that will contain {destination}/{propertiesKey}. It's up to the caller to grab that from the header if they need it for future operations (like Delete). 

*I also had to modify the test for "GET /connections" to work when Rabbit is hosted in a container or VM*