### PR TITLE
Adds Configurable SSL/TLS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ so you must enable it.
 ### Changing Transport Layer
 
 ``` go
-var transport := ...
+var transport *http.Transport
+...
 rmqc.SetTransport(transport)
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,20 +54,13 @@ SSL/TSL is now available, by adding a Transport Layer to the parameters
 of `rabbithole.NewTLSClient`:
 ``` go
 transport := &http.Transport{TLSClientConfig: tlsConfig}
-rmqc, _ := rabbithole.NewTLSClient("https://127.0.0.1:15672", "guest", "guest", transport)
+rmqc, _ := NewTLSClient("https://127.0.0.1:15672", "guest", "guest", transport)
 ```
 However, RabbitMQ-Management does not have SSL/TLS enabled by default,
 so you must enable it.
 
 [API reference](http://godoc.org/github.com/michaelklishin/rabbit-hole) is available on [godoc.org](http://godoc.org).
 
-### Changing Transport Layer
-
-``` go
-var transport *http.Transport
-...
-rmqc.SetTransport(transport)
-```
 
 ### Getting Overview
 
@@ -260,7 +253,23 @@ resp, err := rmqc.DeleteBinding("/", BindingInfo{
 
 ### HTTPS Connections
 
-Added by GrimTheReaper Augest 7th, 2015
+``` go
+var tlsConfig *tls.Config
+
+transport := &http.Transport{TLSClientConfig: tlsConfig}
+
+rmqc, err := NewTLSClient("https://127.0.0.1:15671", "guest", "administrator", transport)
+```
+
+### Changing Transport Layer
+
+``` go
+var transport *http.Transport
+
+... 
+
+rmqc.SetTransport(transport)
+```
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ should be instantiated with `rabbithole.NewClient`:
 rmqc, _ = NewClient("http://127.0.0.1:15672", "guest", "guest")
 ```
 
+SSL/TSL is now available, by adding a Transport Layer to the parameters
+of `rabbithole.NewTLSClient`:
+``` go
+transport := &http.Transport{TLSClientConfig: tlsConfig}
+rmqc, _ := rabbithole.NewTLSClient("https://127.0.0.1:15672", "guest", "guest", transport)
+```
+However, RabbitMQ-Management does not have SSL/TLS enabled by default,
+so you must enable it.
+
 [API reference](http://godoc.org/github.com/michaelklishin/rabbit-hole) is available on [godoc.org](http://godoc.org).
 
 ### Getting Overview
@@ -217,24 +226,24 @@ bs, err := rmqc.ListBindings()
 bs, err := rmqc.ListBindingsIn("/")
 // => []BindingInfo, err
 
-// list bindings of a queue 
+// list bindings of a queue
 bs, err := rmqc.ListQueueBindings("/", "a.queue")
 // => []BindingInfo, err
 
 // declare a binding
 resp, err := rmqc.DeclareBinding("/", BindingInfo{
-	Source: "an.exchange", 
-	Destination: "a.queue", 
-	DestinationType: "queue", 
+	Source: "an.exchange",
+	Destination: "a.queue",
+	DestinationType: "queue",
 	RoutingKey: "#",
 })
 // => *http.Response, err
 
 // deletes individual binding
 resp, err := rmqc.DeleteBinding("/", BindingInfo{
-	Source: "an.exchange", 
-	Destination: "a.queue", 
-	DestinationType: "queue", 
+	Source: "an.exchange",
+	Destination: "a.queue",
+	DestinationType: "queue",
 	RoutingKey: "#",
 	PropertiesKey: "%23",
 })
@@ -264,4 +273,3 @@ TBD
 
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/michaelklishin/rabbit-hole/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-

--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ so you must enable it.
 
 [API reference](http://godoc.org/github.com/michaelklishin/rabbit-hole) is available on [godoc.org](http://godoc.org).
 
+### Changing Transport Layer
+
+``` go
+var transport := ...
+rmqc.SetTransport(transport)
+```
+
 ### Getting Overview
 
 ``` go
@@ -252,8 +259,7 @@ resp, err := rmqc.DeleteBinding("/", BindingInfo{
 
 ### HTTPS Connections
 
-TBD
-
+Added by GrimTheReaper Augest 7th, 2015
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -256,9 +256,11 @@ resp, err := rmqc.DeleteBinding("/", BindingInfo{
 ``` go
 var tlsConfig *tls.Config
 
+...
+
 transport := &http.Transport{TLSClientConfig: tlsConfig}
 
-rmqc, err := NewTLSClient("https://127.0.0.1:15671", "guest", "administrator", transport)
+rmqc, err := NewTLSClient("https://127.0.0.1:15672", "guest", "guest", transport)
 ```
 
 ### Changing Transport Layer

--- a/bindings.go
+++ b/bindings.go
@@ -28,10 +28,10 @@ import (
 
 type BindingInfo struct {
 	// Binding source (exchange name)
-	Source          string                 `json:"source"`
-	Vhost           string                 `json:"vhost"`
+	Source string `json:"source"`
+	Vhost  string `json:"vhost"`
 	// Binding destination (queue or exchange name)
-	Destination     string                 `json:"destination"`
+	Destination string `json:"destination"`
 	// Destination type, either "queue" or "exchange"
 	DestinationType string                 `json:"destination_type"`
 	RoutingKey      string                 `json:"routing_key"`
@@ -46,7 +46,7 @@ func (c *Client) ListBindings() (rec []BindingInfo, err error) {
 		return []BindingInfo{}, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return []BindingInfo{}, err
 	}
 
@@ -64,7 +64,7 @@ func (c *Client) ListBindingsIn(vhost string) (rec []BindingInfo, err error) {
 		return []BindingInfo{}, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return []BindingInfo{}, err
 	}
 
@@ -100,7 +100,7 @@ func (c *Client) ListQueueBindings(vhost, queue string) (rec []BindingInfo, err 
 		return []BindingInfo{}, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return []BindingInfo{}, err
 	}
 

--- a/channels.go
+++ b/channels.go
@@ -5,18 +5,18 @@ import "net/url"
 // Brief (very incomplete) connection information.
 type BriefConnectionDetails struct {
 	// Connection name
-	Name     string `json:"name"`
+	Name string `json:"name"`
 	// Client port
-	PeerPort Port   `json:"peer_port"`
+	PeerPort Port `json:"peer_port"`
 	// Client host
 	PeerHost string `json:"peer_host"`
 }
 
 type ChannelInfo struct {
 	// Channel number
-	Number int    `json:"number"`
+	Number int `json:"number"`
 	// Channel name
-	Name   string `json:"name"`
+	Name string `json:"name"`
 
 	// basic.qos (prefetch count) value used
 	PrefetchCount int `json:"prefetch_count"`
@@ -26,11 +26,11 @@ type ChannelInfo struct {
 	// Number of unacknowledged messages on this channel
 	UnacknowledgedMessageCount int `json:"messages_unacknowledged"`
 	// Number of messages on this channel unconfirmed to publishers
-	UnconfirmedMessageCount    int `json:"messages_unconfirmed"`
+	UnconfirmedMessageCount int `json:"messages_unconfirmed"`
 	// Number of messages on this channel uncommited to message store
-	UncommittedMessageCount    int `json:"messages_uncommitted"`
+	UncommittedMessageCount int `json:"messages_uncommitted"`
 	// Number of acks on this channel uncommited to message store
-	UncommittedAckCount        int `json:"acks_uncommitted"`
+	UncommittedAckCount int `json:"acks_uncommitted"`
 
 	// TODO(mk): custom deserializer to date/time?
 	IdleSince string `json:"idle_since"`
@@ -38,9 +38,9 @@ type ChannelInfo struct {
 	// True if this channel uses publisher confirms
 	UsesPublisherConfirms bool `json:"confirm"`
 	// True if this channel uses transactions
-	Transactional         bool `json:"transactional"`
+	Transactional bool `json:"transactional"`
 	// True if this channel is blocked via channel.flow
-	ClientFlowBlocked     bool `json:"client_flow_blocked"`
+	ClientFlowBlocked bool `json:"client_flow_blocked"`
 
 	User  string `json:"user"`
 	Vhost string `json:"vhost"`
@@ -60,7 +60,7 @@ func (c *Client) ListChannels() (rec []ChannelInfo, err error) {
 		return []ChannelInfo{}, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return []ChannelInfo{}, err
 	}
 
@@ -78,7 +78,7 @@ func (c *Client) GetChannel(name string) (rec *ChannelInfo, err error) {
 		return nil, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return nil, err
 	}
 

--- a/client.go
+++ b/client.go
@@ -16,7 +16,6 @@ type Client struct {
 	// Password to use.
 	Password   string
 	host       string
-	httpclient http.Client
 	transport  *http.Transport
 }
 

--- a/client.go
+++ b/client.go
@@ -14,8 +14,10 @@ type Client struct {
 	// Username to use. This RabbitMQ user must have the "management" tag.
 	Username string
 	// Password to use.
-	Password string
-	host     string
+	Password   string
+	host       string
+	httpclient http.Client
+	transport  *http.Transport
 }
 
 func NewClient(uri string, username string, password string) (me *Client, err error) {
@@ -32,6 +34,29 @@ func NewClient(uri string, username string, password string) (me *Client, err er
 	}
 
 	return me, nil
+}
+
+//NewTLSClient Creates a Client with a Transport Layer; it is up to the developer to make that layer Secure.
+func NewTLSClient(uri string, username string, password string, transport *http.Transport) (me *Client, err error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	me = &Client{
+		Endpoint:  uri,
+		host:      u.Host,
+		Username:  username,
+		Password:  password,
+		transport: transport,
+	}
+
+	return me, nil
+}
+
+//SetTransport changes the Transport Layer that the Client will use.
+func (c *Client) SetTransport(transport *http.Transport) {
+	c.transport = transport
 }
 
 func newGETRequest(client *Client, path string) (*http.Request, error) {
@@ -59,8 +84,12 @@ func newRequestWithBody(client *Client, method string, path string, body []byte)
 }
 
 func executeRequest(client *Client, req *http.Request) (res *http.Response, err error) {
-	httpc := &http.Client{}
-
+	var httpc *http.Client
+	if client.transport != nil {
+		httpc = &http.Client{Transport: client.transport}
+	} else {
+		httpc = &http.Client{}
+	}
 	res, err = httpc.Do(req)
 	if err != nil {
 		return nil, err
@@ -69,10 +98,14 @@ func executeRequest(client *Client, req *http.Request) (res *http.Response, err 
 	return res, nil
 }
 
-func executeAndParseRequest(req *http.Request, rec interface{}) (err error) {
-	client := &http.Client{}
-
-	res, err := client.Do(req)
+func executeAndParseRequest(client *Client, req *http.Request, rec interface{}) (err error) {
+	var httpc *http.Client
+	if client.transport != nil {
+		httpc = &http.Client{Transport: client.transport}
+	} else {
+		httpc = &http.Client{}
+	}
+	res, err := httpc.Do(req)
 	if err != nil {
 		return err
 	}

--- a/connections.go
+++ b/connections.go
@@ -1,6 +1,7 @@
 package rabbithole
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 )
@@ -8,57 +9,57 @@ import (
 // Provides information about connection to a RabbitMQ node.
 type ConnectionInfo struct {
 	// Connection name
-	Name     string `json:"name"`
+	Name string `json:"name"`
 	// Node the client is connected to
-	Node     string `json:"node"`
+	Node string `json:"node"`
 	// Number of open channels
-	Channels int    `json:"channels"`
+	Channels int `json:"channels"`
 	// Connection state
-	State    string `json:"state"`
+	State string `json:"state"`
 	// Connection type, network (via AMQP client) or direct (via direct Erlang client)
-	Type     string `json:"type"`
+	Type string `json:"type"`
 
 	// Server port
-	Port     Port `json:"port"`
+	Port Port `json:"port"`
 	// Client port
 	PeerPort Port `json:"peer_port"`
 
 	// Server host
-	Host     string `json:"host"`
+	Host string `json:"host"`
 	// Client host
 	PeerHost string `json:"peer_host"`
 
 	// Last connection blocking reason, if any
-	LastBlockedBy  string `json:"last_blocked_by"`
+	LastBlockedBy string `json:"last_blocked_by"`
 	// When connection was last blocked
 	LastBlockedAge string `json:"last_blocked_age"`
 
 	// True if connection uses TLS/SSL
-	UsesTLS          bool   `json:"ssl"`
+	UsesTLS bool `json:"ssl"`
 	// Client certificate subject
-	PeerCertSubject  string `json:"peer_cert_subject"`
+	PeerCertSubject string `json:"peer_cert_subject"`
 	// Client certificate validity
 	PeerCertValidity string `json:"peer_cert_validity"`
 	// Client certificate issuer
-	PeerCertIssuer   string `json:"peer_cert_issuer"`
+	PeerCertIssuer string `json:"peer_cert_issuer"`
 
 	// TLS/SSL protocol and version
-	SSLProtocol    string `json:"ssl_protocol"`
+	SSLProtocol string `json:"ssl_protocol"`
 	// Key exchange mechanism
 	SSLKeyExchange string `json:"ssl_key_exchange"`
 	// SSL cipher suite used
-	SSLCipher      string `json:"ssl_cipher"`
+	SSLCipher string `json:"ssl_cipher"`
 	// SSL hash
-	SSLHash        string `json:"ssl_hash"`
+	SSLHash string `json:"ssl_hash"`
 
 	// Protocol, e.g. AMQP 0-9-1 or MQTT 3-1
 	Protocol string `json:"protocol"`
 	User     string `json:"user"`
 	// Virtual host
-	Vhost    string `json:"vhost"`
+	Vhost string `json:"vhost"`
 
 	// Heartbeat timeout
-	Timeout  int `json:"timeout"`
+	Timeout int `json:"timeout"`
 	// Maximum frame size (AMQP 0-9-1)
 	FrameMax int `json:"frame_max"`
 
@@ -66,12 +67,12 @@ type ConnectionInfo struct {
 	ClientProperties Properties `json:"client_properties"`
 
 	// Octets received
-	RecvOct        uint64      `json:"recv_oct"`
+	RecvOct uint64 `json:"recv_oct"`
 	// Octets sent
-	SendOct        uint64      `json:"send_oct"`
-	RecvCount      uint64      `json:"recv_cnt"`
-	SendCount      uint64      `json:"send_cnt"`
-	SendPending    uint64      `json:"send_pend"`
+	SendOct     uint64 `json:"send_oct"`
+	RecvCount   uint64 `json:"recv_cnt"`
+	SendCount   uint64 `json:"send_cnt"`
+	SendPending uint64 `json:"send_pend"`
 	// Ingress data rate
 	RecvOctDetails RateDetails `json:"recv_oct_details"`
 	// Egress data rate
@@ -88,7 +89,7 @@ func (c *Client) ListConnections() (rec []ConnectionInfo, err error) {
 		return []ConnectionInfo{}, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return []ConnectionInfo{}, err
 	}
 
@@ -105,10 +106,12 @@ func (c *Client) GetConnection(name string) (rec *ConnectionInfo, err error) {
 		return nil, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return nil, err
 	}
-
+	if req != nil {
+		fmt.Printf("Request: %v\n", req)
+	}
 	return rec, nil
 }
 
@@ -116,7 +119,7 @@ func (c *Client) GetConnection(name string) (rec *ConnectionInfo, err error) {
 // DELETE /api/connections/{name}
 //
 
-func (c *Client) CloseConnection (name string) (res *http.Response, err error) {
+func (c *Client) CloseConnection(name string) (res *http.Response, err error) {
 	req, err := newRequestWithBody(c, "DELETE", "connections/"+url.QueryEscape(name), nil)
 	if err != nil {
 		return nil, err

--- a/connections.go
+++ b/connections.go
@@ -1,7 +1,6 @@
 package rabbithole
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 )
@@ -109,9 +108,7 @@ func (c *Client) GetConnection(name string) (rec *ConnectionInfo, err error) {
 	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return nil, err
 	}
-	if req != nil {
-		fmt.Printf("Request: %v\n", req)
-	}
+
 	return rec, nil
 }
 

--- a/exchanges.go
+++ b/exchanges.go
@@ -43,7 +43,7 @@ func (c *Client) ListExchanges() (rec []ExchangeInfo, err error) {
 		return []ExchangeInfo{}, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return []ExchangeInfo{}, err
 	}
 
@@ -60,7 +60,7 @@ func (c *Client) ListExchangesIn(vhost string) (rec []ExchangeInfo, err error) {
 		return []ExchangeInfo{}, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return []ExchangeInfo{}, err
 	}
 
@@ -167,7 +167,7 @@ func (c *Client) GetExchange(vhost, exchange string) (rec *DetailedExchangeInfo,
 		return nil, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return nil, err
 	}
 

--- a/misc.go
+++ b/misc.go
@@ -52,7 +52,7 @@ func (c *Client) Overview() (rec *Overview, err error) {
 		return nil, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return nil, err
 	}
 
@@ -75,7 +75,7 @@ func (c *Client) Whoami() (rec *WhoamiInfo, err error) {
 		return nil, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return nil, err
 	}
 

--- a/nodes.go
+++ b/nodes.go
@@ -63,7 +63,7 @@ func (c *Client) ListNodes() (rec []NodeInfo, err error) {
 		return []NodeInfo{}, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return nil, err
 	}
 
@@ -293,7 +293,7 @@ func (c *Client) GetNode(name string) (rec *NodeInfo, err error) {
 		return nil, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return nil, err
 	}
 

--- a/permissions.go
+++ b/permissions.go
@@ -21,9 +21,9 @@ type PermissionInfo struct {
 	// Configuration permissions
 	Configure string `json:"configure"`
 	// Write permissions
-	Write     string `json:"write"`
+	Write string `json:"write"`
 	// Read permissions
-	Read      string `json:"read"`
+	Read string `json:"read"`
 }
 
 // Returns permissions for all users and virtual hosts.
@@ -33,7 +33,7 @@ func (c *Client) ListPermissions() (rec []PermissionInfo, err error) {
 		return []PermissionInfo{}, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return []PermissionInfo{}, err
 	}
 
@@ -51,7 +51,7 @@ func (c *Client) ListPermissionsOf(username string) (rec []PermissionInfo, err e
 		return []PermissionInfo{}, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return []PermissionInfo{}, err
 	}
 
@@ -69,7 +69,7 @@ func (c *Client) GetPermissionsIn(vhost, username string) (rec PermissionInfo, e
 		return PermissionInfo{}, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return PermissionInfo{}, err
 	}
 

--- a/policies.go
+++ b/policies.go
@@ -16,14 +16,14 @@ type NodeNames []string
 // Represents a configured policy.
 type Policy struct {
 	// Virtual host this policy is in.
-	Vhost      string           `json:"vhost"`
+	Vhost string `json:"vhost"`
 	// Regular expression pattern used to match queues and exchanges,
 	// , e.g. "^ha\..+"
-	Pattern    string           `json:"pattern"`
+	Pattern string `json:"pattern"`
 	// What this policy applies to: "queues", "exchanges", etc.
-	ApplyTo    string           `json:"apply-to"`
-	Name       string           `json:"name"`
-	Priority   int              `json:"priority"`
+	ApplyTo  string `json:"apply-to"`
+	Name     string `json:"name"`
+	Priority int    `json:"priority"`
 	// Additional arguments added to the entities (queues,
 	// exchanges or both) that match a policy
 	Definition PolicyDefinition `json:"definition"`
@@ -40,7 +40,7 @@ func (c *Client) ListPolicies() (rec []Policy, err error) {
 		return nil, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return nil, err
 	}
 
@@ -58,7 +58,7 @@ func (c *Client) ListPoliciesIn(vhost string) (rec []Policy, err error) {
 		return nil, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return nil, err
 	}
 
@@ -76,7 +76,7 @@ func (c *Client) GetPolicy(vhost, name string) (rec *Policy, err error) {
 		return nil, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return nil, err
 	}
 

--- a/queues.go
+++ b/queues.go
@@ -164,7 +164,7 @@ func (c *Client) ListQueues() (rec []QueueInfo, err error) {
 		return []QueueInfo{}, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return []QueueInfo{}, err
 	}
 
@@ -181,7 +181,7 @@ func (c *Client) ListQueuesIn(vhost string) (rec []QueueInfo, err error) {
 		return []QueueInfo{}, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return []QueueInfo{}, err
 	}
 
@@ -198,7 +198,7 @@ func (c *Client) GetQueue(vhost, queue string) (rec *DetailedQueueInfo, err erro
 		return nil, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return nil, err
 	}
 

--- a/users.go
+++ b/users.go
@@ -10,7 +10,7 @@ type UserInfo struct {
 	Name         string `json:"name"`
 	PasswordHash string `json:"password_hash"`
 	// Tags control permissions. Built-in tags: administrator, management, policymaker.
-	Tags         string `json:"tags"`
+	Tags string `json:"tags"`
 }
 
 // Settings used to create users. Tags must be comma-separated.
@@ -40,7 +40,7 @@ func (c *Client) ListUsers() (rec []UserInfo, err error) {
 		return []UserInfo{}, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return []UserInfo{}, err
 	}
 
@@ -58,7 +58,7 @@ func (c *Client) GetUser(username string) (rec *UserInfo, err error) {
 		return nil, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return nil, err
 	}
 

--- a/vhosts.go
+++ b/vhosts.go
@@ -85,7 +85,7 @@ func (c *Client) ListVhosts() (rec []VhostInfo, err error) {
 		return []VhostInfo{}, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return []VhostInfo{}, err
 	}
 
@@ -103,7 +103,7 @@ func (c *Client) GetVhost(vhostname string) (rec *VhostInfo, err error) {
 		return nil, err
 	}
 
-	if err = executeAndParseRequest(req, &rec); err != nil {
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
I added SSL/TLS support by allowing the dev to use `http.Transport`, which allows them to throw in a `tls.Config` object to make the connection run through SSL/TLS.