### PR TITLE
Handle when rabbitmq sends a port value in a string

### DIFF
--- a/common.go
+++ b/common.go
@@ -1,10 +1,27 @@
 package rabbithole
 
+import "strconv"
+
 // Extra arguments as a map (on queues, bindings, etc)
 type Properties map[string]interface{}
 
 // Port used by RabbitMQ or clients
 type Port int
+
+func (p *Port) UnmarshalJSON(b []byte) error {
+	stringValue := string(b)
+	var parsed int64
+	var err error
+	if stringValue[0] == '"' && stringValue[len(stringValue)-1] == '"' {
+		parsed, err = strconv.ParseInt(stringValue[1:len(stringValue)-1], 10, 32)
+	} else {
+		parsed, err = strconv.ParseInt(stringValue, 10, 32)
+	}
+	if err == nil {
+		*p = Port(int(parsed))
+	}
+	return err
+}
 
 // Rate of change of a numerical value
 type RateDetails struct {


### PR DESCRIPTION
This fixes #60. While I could have fixed this particular problem by adding `,string` to the tag for Port in `BrokerContext`, its not clear to me whether the is a problem for all versions of Rabbitmq or just this particular one.

Let me know if there are any changes that you'd like me to make.