### PR TITLE
Add remaining attributes to MessageStats struct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ The workflow is pretty standard:
 
 ## Running Tests
 
+Create a virtual host `rabbit/hole` and assign it guest permissions
+
 The project uses [Ginkgo](http://onsi.github.io/ginkgo/) and [Gomega](https://github.com/onsi/gomega)
 for the test suite.
 

--- a/common.go
+++ b/common.go
@@ -40,6 +40,14 @@ type BrokerContext struct {
 
 // Basic published messages statistics
 type MessageStats struct {
-	Publish        int         `json:"publish"`
-	PublishDetails RateDetails `json:"publish_details"`
+	Publish           int         `json:"publish"`
+	PublishDetails    RateDetails `json:"publish_details"`
+	DeliverGet        int         `json:"deliver_get"`
+	DeliverGetDetails RateDetails `json:"deliver_get_details"`
+	Redeliver         int         `json:"redeliver"`
+	RedeliverDetails  RateDetails `json:"redeliver_details"`
+	Get               int         `json:"get"`
+	GetDetails        RateDetails `json:"get_details"`
+	GetNoAck          int         `json:"get_no_ack"`
+	GetNoAckDetails   RateDetails `json:"get_no_ack_details"`
 }

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -3,10 +3,10 @@ package rabbithole
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/url"
 	"strings"
 	"time"
-	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -59,7 +59,7 @@ func ensureNonZeroMessageRate(ch *amqp.Channel) {
 }
 
 // Wait for the list of connections to reach the expected length
-func listConnectionsUntil(c *Client, i int){
+func listConnectionsUntil(c *Client, i int) {
 	xs, _ := c.ListConnections()
 	// Avoid infinity loops by breaking it after 30s
 	breakLoop := 0
@@ -103,6 +103,9 @@ var _ = Describe("Rabbithole", func() {
 
 			Ω(res.Node).ShouldNot(BeNil())
 			Ω(res.StatisticsDBNode).ShouldNot(BeNil())
+			Ω(res.MessageStats).ShouldNot(BeNil())
+			Ω(res.MessageStats.DeliverGetDetails).ShouldNot(BeNil())
+			Ω(res.MessageStats.DeliverGetDetails.Rate).Should(BeNumerically("==", 0))
 
 			fanoutExchange := ExchangeType{Name: "fanout", Description: "AMQP fanout exchange, as per the AMQP specification", Enabled: true}
 			Ω(res.ExchangeTypes).Should(ContainElement(fanoutExchange))


### PR DESCRIPTION
This pull requests adds remaining fields: `deliver_get`, `redeliver`, `get`, `get_no_ack` to the `MessageStats` struct

```json
"MessageStats": {
    "publish": 55194,
    "publish_details": {
      "rate": 271.2
    },
    "deliver_get": 100,
    "deliver_get_details": {
      "rate": 0
    },
    "redeliver": 0,
    "redeliver_details": {
      "rate": 0
    },
    "get": 0,
    "get_details": {
      "rate": 0
    },
    "get_no_ack": 100,
    "get_no_ack_details": {
      "rate": 0
    }
  }
```