### PR TITLE
Added Deliver and DeliverNoAck fields to MessageStats struct

### DIFF
--- a/common.go
+++ b/common.go
@@ -40,14 +40,18 @@ type BrokerContext struct {
 
 // Basic published messages statistics
 type MessageStats struct {
-	Publish           int         `json:"publish"`
-	PublishDetails    RateDetails `json:"publish_details"`
-	DeliverGet        int         `json:"deliver_get"`
-	DeliverGetDetails RateDetails `json:"deliver_get_details"`
-	Redeliver         int         `json:"redeliver"`
-	RedeliverDetails  RateDetails `json:"redeliver_details"`
-	Get               int         `json:"get"`
-	GetDetails        RateDetails `json:"get_details"`
-	GetNoAck          int         `json:"get_no_ack"`
-	GetNoAckDetails   RateDetails `json:"get_no_ack_details"`
+	Publish             int         `json:"publish"`
+	PublishDetails      RateDetails `json:"publish_details"`
+	Deliver             int         `json:"deliver"`
+	DeliverDetails      RateDetails `json:"deliver_details"`
+	DeliverNoAck        int         `json:"deliver_noack"`
+	DeliverNoAckDetails RateDetails `json:"deliver_noack_details"`
+	DeliverGet          int         `json:"deliver_get"`
+	DeliverGetDetails   RateDetails `json:"deliver_get_details"`
+	Redeliver           int         `json:"redeliver"`
+	RedeliverDetails    RateDetails `json:"redeliver_details"`
+	Get                 int         `json:"get"`
+	GetDetails          RateDetails `json:"get_details"`
+	GetNoAck            int         `json:"get_no_ack"`
+	GetNoAckDetails     RateDetails `json:"get_no_ack_details"`
 }

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -64,7 +64,7 @@ func listConnectionsUntil(c *Client, i int) {
 	// Avoid infinity loops by breaking it after 30s
 	breakLoop := 0
 	for i != len(xs) {
-		if (breakLoop == 300) {
+		if breakLoop == 300 {
 			fmt.Printf("Stopping listConnectionsUntil loop: expected %v obtained %v", i, len(xs))
 			break
 		}
@@ -108,6 +108,10 @@ var _ = Describe("Rabbithole", func() {
 			Ω(res.Node).ShouldNot(BeNil())
 			Ω(res.StatisticsDBNode).ShouldNot(BeNil())
 			Ω(res.MessageStats).ShouldNot(BeNil())
+			Ω(res.MessageStats.DeliverDetails).ShouldNot(BeNil())
+			Ω(res.MessageStats.DeliverDetails.Rate).Should(BeNumerically(">=", 0))
+			Ω(res.MessageStats.DeliverNoAckDetails).ShouldNot(BeNil())
+			Ω(res.MessageStats.DeliverNoAckDetails.Rate).Should(BeNumerically(">=", 0))
 			Ω(res.MessageStats.DeliverGetDetails).ShouldNot(BeNil())
 			Ω(res.MessageStats.DeliverGetDetails.Rate).Should(BeNumerically(">=", 0))
 


### PR DESCRIPTION
Exposing fields previously ignored from API response, these are needed for metrics.