### PR TITLE
Add ConsumerUtilisation to QueueInfo

### DIFF
--- a/queues.go
+++ b/queues.go
@@ -63,6 +63,8 @@ type QueueInfo struct {
 	Memory int64 `json:"memory"`
 	// How many consumers this queue has
 	Consumers int `json:"consumers"`
+	// Utilisation of all the consumers
+	ConsumerUtilisation float64 `json:"consumer_utilisation"`
 	// If there is an exclusive consumer, its consumer tag
 	ExclusiveConsumerTag string `json:"exclusive_consumer_tag"`
 


### PR DESCRIPTION
Currently the ConsumerUtilisation is available on the API response from `/queues`, but is not returned by rabbit-hole. This adds that to the QueueInfo object.

## Notes
The `consumer_utilisation` property in the response from RabbitMQ can be null when there are no consumers, or there are no messages. This gets marshalled to 0, which is appropriate and matches the behaviour of the RabbitMQ management GUI.