### PR TITLE
Fix type of ConsumerUtilisation property on QueueInfo struct

### DIFF
--- a/queues.go
+++ b/queues.go
@@ -64,7 +64,7 @@ type QueueInfo struct {
 	// How many consumers this queue has
 	Consumers int `json:"consumers"`
 	// Utilisation of all the consumers
-	ConsumerUtilisation float64 `json:"consumer_utilisation"`
+	ConsumerUtilisation string `json:"consumer_utilisation"`
 	// If there is an exclusive consumer, its consumer tag
 	ExclusiveConsumerTag string `json:"exclusive_consumer_tag"`
 


### PR DESCRIPTION
Addresses bug with inability to deserialize QueueInfo object. consumer_utilisation is returned as a string by the RabbitMQ API, not a float64.

Bug discovered on and fix tested against RabbitMQ v3.5.3.

Related to: https://github.com/michaelklishin/rabbit-hole/pull/79