### PR TITLE
Wait for stats to be published in new management plugin

### DIFF
--- a/bin/ci/before_build.sh
+++ b/bin/ci/before_build.sh
@@ -8,6 +8,8 @@ $RABBITHOLE_RABBITMQCTL add_vhost /
 $RABBITHOLE_RABBITMQCTL add_user guest guest
 $RABBITHOLE_RABBITMQCTL set_permissions -p / guest ".*" ".*" ".*"
 
+# Reduce retention policy for faster publishing of stats
+$RABBITHOLE_RABBITMQCTL eval 'supervisor2:terminate_child(rabbit_mgmt_sup_sup, rabbit_mgmt_sup), application:set_env(rabbitmq_management, sample_retention_policies, [{global, [{605, 1}]}, {basic, [{605, 1}]}, {detailed, [{10, 1}]}]), rabbit_mgmt_sup_sup:start_child().'
 
 $RABBITHOLE_RABBITMQCTL add_vhost "rabbit/hole"
 $RABBITHOLE_RABBITMQCTL set_permissions -p "rabbit/hole" guest ".*" ".*" ".*"

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -76,7 +76,7 @@ func listConnectionsUntil(c *Client, i int) {
 }
 
 func awaitEventPropagation() {
-	time.Sleep(150 * time.Millisecond)
+	time.Sleep(1150 * time.Millisecond)
 }
 
 type portTestStruct struct {
@@ -127,6 +127,7 @@ var _ = Describe("Rabbithole", func() {
 			listConnectionsUntil(rmqc, 0)
 			conn := openConnection("/")
 
+			awaitEventPropagation()
 			xs, err := rmqc.ListConnections()
 			Ω(err).Should(BeNil())
 
@@ -303,7 +304,7 @@ var _ = Describe("Rabbithole", func() {
 
 			// give internal events a moment to be
 			// handled
-			time.Sleep(300 * time.Millisecond)
+			awaitEventPropagation()
 
 			xs, err := rmqc.ListChannels()
 			Ω(err).Should(BeNil())
@@ -341,7 +342,7 @@ var _ = Describe("Rabbithole", func() {
 
 			// give internal events a moment to be
 			// handled
-			time.Sleep(300 * time.Millisecond)
+			awaitEventPropagation()
 
 			xs, err := rmqc.ListConnections()
 			Ω(err).Should(BeNil())
@@ -372,7 +373,7 @@ var _ = Describe("Rabbithole", func() {
 
 			// give internal events a moment to be
 			// handled
-			time.Sleep(300 * time.Millisecond)
+			awaitEventPropagation()
 
 			xs, err := rmqc.ListChannels()
 			Ω(err).Should(BeNil())


### PR DESCRIPTION
The new mgmt plugin developed in https://github.com/rabbitmq/rabbitmq-management/issues/236 publishes the stats in batches using the smallest sample retention policy interval available.

This patch sets the interval to 1s and add a minimal wait for it on the tests. Tests will be slower, but should run in less than 50s.
