### PR TITLE
Make non-2xx responses fail visibly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ _testmain.go
 bin/*
 src/github.com
 src/code.google.com
+.idea/
+rabbit-hole.iml

--- a/client.go
+++ b/client.go
@@ -126,7 +126,3 @@ func executeAndParseRequest(client *Client, req *http.Request, rec interface{}) 
 
 	return nil
 }
-
-func isNotFound(res *http.Response) bool {
-	return res.StatusCode == http.StatusNotFound
-}

--- a/client.go
+++ b/client.go
@@ -115,8 +115,8 @@ func executeAndParseRequest(client *Client, req *http.Request, rec interface{}) 
 	}
 	defer res.Body.Close() // always close body
 
-	if isNotFound(res) {
-		return errors.New("not found")
+	if res.StatusCode != 200 {
+		return errors.New(res.Status)
 	}
 
 	err = json.NewDecoder(res.Body).Decode(&rec)


### PR DESCRIPTION
Not failing on any HTTP code other than 200 breaks the Rule of Repair: when you must fail, fail noisily and as soon as possible.

I thought I was getting valid responses back and there was an error in deserialization until I realized that I simply wasn't getting a 200 back. Instead I was getting a 401 (Unauthorized). Because the library wasn't sensitive to this, I wasted a lot of time looking in the wrong place.