### PR TITLE
Adds Shovel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,31 @@ resp, err := rmqc.DeleteBinding("/", BindingInfo{
 // => *http.Response, err
 ```
 
+### Operations on Shovels
+
+``` go
+qs, err := rmqc.ListShovels()
+// => []ShovelInfo, err
+
+// list shovels in a vhost
+qs, err := rmqc.ListShovelsIn("/")
+// => []ShovelInfo, err
+
+// information about an individual shovel
+q, err := rmqc.GetShovel("/", "a.shovel")
+// => ShovelInfo, err
+
+// declares a shovel
+shovelDetails := rabbithole.ShovelDefinition{SourceURI: "amqp://sourceURI", SourceQueue: "mySourceQueue", DestinationURI: "amqp://destinationURI", DestinationQueue: "myDestQueue", AddForwardHeaders: true, AckMode: "on-confirm", DeleteAfter: "never"}
+resp, err := rmqc.DeclareShovel("/", "a.shovel", shovelDetails)
+// => *http.Response, err
+
+// deletes an individual shovel
+resp, err := rmqc.DeleteShovel("/", "a.shovel")
+// => *http.Response, err
+
+```
+
 ### HTTPS Connections
 
 ``` go

--- a/bin/ci/before_build.bat
+++ b/bin/ci/before_build.bat
@@ -1,0 +1,27 @@
+@echo off
+setlocal enabledelayedexpansion
+
+if "!RABBITHOLE_RABBITMQCTL!"=="" (
+    set RABBITHOLE_RABBITMQCTL=rabbitmqctl
+)
+
+if "!RABBITHOLE_RABBITMQ_PLUGINS!"=="" (
+    set RABBITHOLE_RABBITMQ_PLUGINS=rabbitmq-plugins
+)
+
+REM guest:guest has full access to /
+
+call %RABBITHOLE_RABBITMQCTL% add_vhost /
+call %RABBITHOLE_RABBITMQCTL% add_user guest guest
+call %RABBITHOLE_RABBITMQCTL% set_permissions -p / guest ".*" ".*" ".*"
+
+REM Reduce retention policy for faster publishing of stats
+call %RABBITHOLE_RABBITMQCTL% eval "supervisor2:terminate_child(rabbit_mgmt_sup_sup, rabbit_mgmt_sup), application:set_env(rabbitmq_management,       sample_retention_policies, [{global, [{605, 1}]}, {basic, [{605, 1}]}, {detailed, [{10, 1}]}]), rabbit_mgmt_sup_sup:start_child()."
+call %RABBITHOLE_RABBITMQCTL% eval "supervisor2:terminate_child(rabbit_mgmt_agent_sup_sup, rabbit_mgmt_agent_sup), application:set_env(rabbitmq_management_agent, sample_retention_policies, [{global, [{605, 1}]}, {basic, [{605, 1}]}, {detailed, [{10, 1}]}]), rabbit_mgmt_agent_sup_sup:start_child()."
+
+call %RABBITHOLE_RABBITMQCTL% add_vhost "rabbit/hole"
+call %RABBITHOLE_RABBITMQCTL% set_permissions -p "rabbit/hole" guest ".*" ".*" ".*"
+
+REM Enable shovel plugin
+call %RABBITHOLE_RABBITMQ_PLUGINS% enable rabbitmq_shovel
+call %RABBITHOLE_RABBITMQ_PLUGINS% enable rabbitmq_shovel_management

--- a/bin/ci/before_build.sh
+++ b/bin/ci/before_build.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 ${RABBITHOLE_RABBITMQCTL:="sudo rabbitmqctl"}
+${RABBITHOLE_RABBITMQ_PLUGINS:="sudo rabbitmq-plugins"}
 
 # guest:guest has full access to /
 
@@ -14,3 +15,7 @@ $RABBITHOLE_RABBITMQCTL eval 'supervisor2:terminate_child(rabbit_mgmt_agent_sup_
 
 $RABBITHOLE_RABBITMQCTL add_vhost "rabbit/hole"
 $RABBITHOLE_RABBITMQCTL set_permissions -p "rabbit/hole" guest ".*" ".*" ".*"
+
+# Enable shovel plugin
+$RABBITHOLE_RABBITMQ_PLUGINS enable rabbitmq_shovel
+$RABBITHOLE_RABBITMQ_PLUGINS enable rabbitmq_shovel_management

--- a/shovels.go
+++ b/shovels.go
@@ -1,0 +1,140 @@
+package rabbithole
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// ShovelInfo contains the configuration of a shovel
+type ShovelInfo struct {
+	// Shovel name
+	Name string `json:"name"`
+	// Virtual host this shovel belongs to
+	Vhost string `json:"vhost"`
+	// Component shovels belong to
+	Component string `json:"component"`
+	// Details the configuration values of the shovel
+	Definition ShovelDefinition `json:"value"`
+}
+
+// ShovelDefinition contains the details of the shovel configuration
+type ShovelDefinition struct {
+	SourceURI              string `json:"src-uri"`
+	SourceExchange         string `json:"src-exchange,omitempty"`
+	SourceExchangeKey      string `json:"src-exchange-key,omitempty"`
+	SourceQueue            string `json:"src-queue,omitempty"`
+	DestinationURI         string `json:"dest-uri"`
+	DestinationExchange    string `json:"dest-exchange,omitempty"`
+	DestinationExchangeKey string `json:"dest-exchange-key,omitempty"`
+	DestinationQueue       string `json:"dest-queue,omitempty"`
+	PrefetchCount          int    `json:"prefetch-count,omitempty"`
+	ReconnectDelay         int    `json:"reconnect-delay,omitempty"`
+	AddForwardHeaders      bool   `json:"add-forward-headers"`
+	AckMode                string `json:"ack-mode"`
+	DeleteAfter            string `json:"delete-after"`
+}
+
+// ShovelDefinitionDTO provides a data transfer object
+type ShovelDefinitionDTO struct {
+	Definition ShovelDefinition `json:"value"`
+}
+
+//
+// GET /api/parameters/shovel
+//
+
+// ListShovels returns all shovels
+func (c *Client) ListShovels() (rec []ShovelInfo, err error) {
+	req, err := newGETRequest(c, "parameters/shovel")
+	if err != nil {
+		return []ShovelInfo{}, err
+	}
+
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
+		return []ShovelInfo{}, err
+	}
+
+	return rec, nil
+}
+
+//
+// GET /api/parameters/shovel/{vhost}
+//
+
+// ListShovelsIn returns all shovels in a vhost
+func (c *Client) ListShovelsIn(vhost string) (rec []ShovelInfo, err error) {
+	req, err := newGETRequest(c, "parameters/shovel/"+PathEscape(vhost))
+	if err != nil {
+		return []ShovelInfo{}, err
+	}
+
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
+		return []ShovelInfo{}, err
+	}
+
+	return rec, nil
+}
+
+//
+// GET /api/parameters/shovel/{vhost}/{name}
+//
+
+// GetShovel returns a shovel configuration
+func (c *Client) GetShovel(vhost, shovel string) (rec *ShovelInfo, err error) {
+	req, err := newGETRequest(c, "parameters/shovel/"+PathEscape(vhost)+"/"+PathEscape(shovel))
+
+	if err != nil {
+		return nil, err
+	}
+
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
+		return nil, err
+	}
+
+	return rec, nil
+}
+
+//
+// PUT /api/parameters/shovel/{vhost}/{name}
+//
+
+// DeclareShovel creates a shovel
+func (c *Client) DeclareShovel(vhost, shovel string, info ShovelDefinition) (res *http.Response, err error) {
+	shovelDTO := ShovelDefinitionDTO{Definition: info}
+
+	body, err := json.Marshal(shovelDTO)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := newRequestWithBody(c, "PUT", "parameters/shovel/"+PathEscape(vhost)+"/"+PathEscape(shovel), body)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err = executeRequest(c, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+//
+// DELETE /api/parameters/shovel/{vhost}/{name}
+//
+
+// DeleteShovel a shovel
+func (c *Client) DeleteShovel(vhost, shovel string) (res *http.Response, err error) {
+	req, err := newRequestWithBody(c, "DELETE", "parameters/shovel/"+PathEscape(vhost)+"/"+PathEscape(shovel), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err = executeRequest(c, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
Adds supports for shovels

- ListShovels
- ListShovelsIn
- GetShovel
- DeclareShovel
- DeleteShovel

Also enabled 'rabbitmq_shovel' and 'rabbitmq_shovel_management' plugins in before_build as well as created a .bat equivalent for running tests on Windows.

As far as tests are concerned, I just have the one that creates a shovel, checks the config, then deletes it. Are there other tests you would like to see?

Fixes https://github.com/michaelklishin/rabbit-hole/issues/91

As a side note, I get an error with the second eval.

```
call %RABBITHOLE_RABBITMQCTL% eval "supervisor2:terminate_child(rabbit_mgmt_agent_sup_sup, rabbit_mgmt_agent_sup), application:set_env(rabbitmq_management_agent, sample_retention_policies, [{global, [{605, 1}]}, {basic, [{605, 1}]}, {detailed, [{10, 1}]}]), rabbit_mgmt_agent_sup_sup:start_child()."

Error: {noproc,{gen_server,call,
                           [rabbit_mgmt_agent_sup_sup,
                            {terminate_child,rabbit_mgmt_agent_sup},
                            infinity]}}
```