### PR TITLE
Support PUT /api/users/{name} with empty password_hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ x, err := rmqc.GetUser("my.user")
 resp, err := rmqc.PutUser("my.user", UserSettings{Password: "s3krE7", Tags: "management,policymaker"})
 // => *http.Response, err
 
+// creates or updates individual user with no password
+resp, err := rmqc.PutUserWithoutPassword("my.user", UserSettings{Tags: "management,policymaker"})
+// => *http.Response, err
+
 // deletes individual user
 resp, err := rmqc.DeleteUser("my.user")
 // => *http.Response, err

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -681,6 +681,23 @@ var _ = Describe("Rabbithole", func() {
 			Ω(u.PasswordHash).ShouldNot(BeNil())
 			Ω(u.Tags).Should(Equal("policymaker,management"))
 		})
+
+		It("updates the user with no password", func() {
+			info := UserSettings{Tags: "policymaker, management"}
+			resp, err := rmqc.PutUserWithoutPassword("rabbithole", info)
+			Ω(err).Should(BeNil())
+			Ω(resp.Status).Should(HavePrefix("20"))
+
+			// give internal events a moment to be
+			// handled
+			awaitEventPropagation()
+
+			u, err := rmqc.GetUser("rabbithole")
+			Ω(err).Should(BeNil())
+
+			Ω(u.PasswordHash).Should(BeEquivalentTo(""))
+			Ω(u.Tags).Should(Equal("policymaker,management"))
+		})
 	})
 
 	Context("DELETE /users/{name}", func() {

--- a/users.go
+++ b/users.go
@@ -88,6 +88,25 @@ func (c *Client) PutUser(username string, info UserSettings) (res *http.Response
 	return res, nil
 }
 
+func (c *Client) PutUserWithoutPassword(username string, info UserSettings) (res *http.Response, err error) {
+	body, err := json.Marshal(UserInfo{Tags: info.Tags})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := newRequestWithBody(c, "PUT", "users/"+PathEscape(username), body)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err = executeRequest(c, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
 //
 // DELETE /api/users/{name}
 //


### PR DESCRIPTION
According to the [RabbitMQ Management HTTP API documentation](https://cdn.rawgit.com/rabbitmq/rabbitmq-management/rabbitmq_v3_6_9/priv/www/api/index.html), calling `PUT /api/users/{name}` with an empty password_hash field disables a user's password, just like the `rabbitmqctl clear_password {username}` command.
I implemented this feature with the new `PutUserWithoutPassword` method.