### PR TITLE
Be able to specify password_hash when creating a new user

### DIFF
--- a/exchanges.go
+++ b/exchanges.go
@@ -32,8 +32,8 @@ type ExchangeInfo struct {
 type ExchangeSettings struct {
 	Type       string                 `json:"type"`
 	Durable    bool                   `json:"durable"`
-	AutoDelete bool                   `json:"auto_delete"`
-	Arguments  map[string]interface{} `json:"arguments"`
+	AutoDelete bool                   `json:"auto_delete,omitempty"`
+	Arguments  map[string]interface{} `json:"arguments,omitempty"`
 }
 
 func (c *Client) ListExchanges() (rec []ExchangeInfo, err error) {

--- a/queues.go
+++ b/queues.go
@@ -249,9 +249,10 @@ func (c *Client) GetQueueWithParameters(vhost, queue string, qs url.Values) (rec
 //
 
 type QueueSettings struct {
+	Type       string                 `json:"type"`
 	Durable    bool                   `json:"durable"`
-	AutoDelete bool                   `json:"auto_delete"`
-	Arguments  map[string]interface{} `json:"arguments"`
+	AutoDelete bool                   `json:"auto_delete,omitempty"`
+	Arguments  map[string]interface{} `json:"arguments,omitempty"`
 }
 
 func (c *Client) DeclareQueue(vhost, queue string, info QueueSettings) (res *http.Response, err error) {

--- a/users.go
+++ b/users.go
@@ -14,11 +14,11 @@ type UserInfo struct {
 
 // Settings used to create users. Tags must be comma-separated.
 type UserSettings struct {
-	Name string `json:"name,omitempty"`
+	Name string `json:"name"`
 	// Tags control permissions. Administrator grants full
 	// permissions, management grants management UI and HTTP API
 	// access, policymaker grants policy management permissions.
-	Tags string `json:"tags,omitempty"`
+	Tags string `json:"tags"`
 
 	// *never* returned by RabbitMQ. Set by the client
 	// to create/update a user. MK.

--- a/users.go
+++ b/users.go
@@ -14,15 +14,16 @@ type UserInfo struct {
 
 // Settings used to create users. Tags must be comma-separated.
 type UserSettings struct {
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 	// Tags control permissions. Administrator grants full
 	// permissions, management grants management UI and HTTP API
 	// access, policymaker grants policy management permissions.
-	Tags string `json:"tags"`
+	Tags string `json:"tags,omitempty"`
 
 	// *never* returned by RabbitMQ. Set by the client
 	// to create/update a user. MK.
-	Password string `json:"password"`
+	Password     string `json:"password,omitempty"`
+	PasswordHash string `json:"password_hash,omitempty"`
 }
 
 //


### PR DESCRIPTION
As indicated https://rawcdn.githack.com/rabbitmq/rabbitmq-management/v3.7.7/priv/www/api/index.html when creating a user it is possible as well to send the password hash.
I've modified UserSettings to have that option.