### PR TITLE
Change *http.Transport to http.RoundTripper

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ rmqc, err := NewTLSClient("https://127.0.0.1:15672", "guest", "guest", transport
 ### Changing Transport Layer
 
 ``` go
-var transport *http.Transport
+var transport http.RoundTripper
 
 ...
 

--- a/client.go
+++ b/client.go
@@ -17,7 +17,7 @@ type Client struct {
 	// Password to use.
 	Password  string
 	host      string
-	transport *http.Transport
+	transport http.RoundTripper
 	timeout   time.Duration
 }
 
@@ -38,7 +38,7 @@ func NewClient(uri string, username string, password string) (me *Client, err er
 }
 
 // Creates a client with a transport; it is up to the developer to make that layer secure.
-func NewTLSClient(uri string, username string, password string, transport *http.Transport) (me *Client, err error) {
+func NewTLSClient(uri string, username string, password string, transport http.RoundTripper) (me *Client, err error) {
 	u, err := url.Parse(uri)
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func NewTLSClient(uri string, username string, password string, transport *http.
 }
 
 //SetTransport changes the Transport Layer that the Client will use.
-func (c *Client) SetTransport(transport *http.Transport) {
+func (c *Client) SetTransport(transport http.RoundTripper) {
 	c.transport = transport
 }
 


### PR DESCRIPTION
https://golang.org/pkg/net/http/#RoundTripper

This will allow anyone to pass through custom transport implementations, such as logging transport we use over in Terraform:

https://github.com/hashicorp/terraform/blob/master/helper/logging/transport.go

`*http.Transport` implements this interface so this should not break anything.

I tried running tests via `make test` but they mostly fail (on master) for me. It may be just different environment, I don't know - I hope my changes didn't break anything. 🤞 