### PR TITLE
Fix go module support in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ dist: xenial
 language: go
 
 go:
-  - "1.11"
-  - "1.10"
-  - "1.9"
   - tip
+  - "1.12"
+  - "1.11"
+
+env:
+  - GO111MODULE=on
 
 services:
   - rabbitmq

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This library is a [RabbitMQ HTTP API](https://raw.githack.com/rabbitmq/rabbitmq-
 
 ## Supported Go Versions
 
-Rabbit Hole supports 3 most recent Go releases.
+Rabbit Hole supports the last 2 stable Go versions, as well as the version in development (a.k.a. master).
 
 
 ## Supported RabbitMQ Versions


### PR DESCRIPTION
Add Golang v1.12, drop v1.9 & v1.10. Module support was introduced in
v1.11: https://blog.golang.org/using-go-modules

Related to #128