### PR TITLE
support retrieving the exchange publishIn/publishOut stats

### DIFF
--- a/exchanges.go
+++ b/exchanges.go
@@ -156,8 +156,9 @@ type DetailedExchangeInfo struct {
 	Internal   bool                   `json:"internal"`
 	Arguments  map[string]interface{} `json:"arguments"`
 
-	Incoming []ExchangeIngressDetails `json:"incoming"`
-	Outgoing []ExchangeEgressDetails  `json:"outgoing"`
+	Incoming     []ExchangeIngressDetails `json:"incoming"`
+	Outgoing     []ExchangeEgressDetails  `json:"outgoing"`
+	PublishStats IngressEgressStats       `json:"message_stats"`
 }
 
 func (c *Client) GetExchange(vhost, exchange string) (rec *DetailedExchangeInfo, err error) {


### PR DESCRIPTION
Hi Michael,

Thank you very much for the friendly go library to get various details from RabbitMQ Management.
While I was testing the library, I found that the function "rmqc.GetExchange" was not retrieving the "PublinIn, PublishOut" message stats of a exchange, Hence I have included the "PublishStats" to "struct DetailedExchangeInfo" after which I am able to retrieve the Publish IN/OUT rates as well as Count.

Sincerely,
Rajendra N Acharya

Below is the test execution results after my changes.

```
06/10/2019@11:15:38 exchange-publish-stats: /home/raachary/github/login/rabbit-hole
raachary@ubuntu> make
go test -race -v
=== RUN   TestRabbitHole
Running Suite: Rabbithole Suite
===============================
Random Seed: 1560145547
Will run 66 of 66 specs

•
------------------------------
• [SLOW TEST:5.749 seconds]
Rabbithole
/home/raachary/github/login/rabbit-hole/rabbithole_test.go:83
  GET /overview
  /home/raachary/github/login/rabbit-hole/rabbithole_test.go:133
    returns decoded response
    /home/raachary/github/login/rabbit-hole/rabbithole_test.go:134
------------------------------
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
Ran 66 of 66 Specs in 69.826 seconds
SUCCESS! -- 66 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestRabbitHole (69.83s)
PASS
ok  	github.com/michaelklishin/rabbit-hole	70.904s
06/10/2019@11:16:57 exchange-publish-stats: /home/raachary/github/login/rabbit-hole
raachary@ubuntu> 
```