### PR TITLE
Fix QueueInfo.Status json tag

### DIFF
--- a/queues.go
+++ b/queues.go
@@ -57,7 +57,7 @@ type QueueInfo struct {
 	// RabbitMQ node that hosts master for this queue
 	Node string `json:"node"`
 	// Queue status
-	Status string `json:"status"`
+	Status string `json:"state"`
 
 	// Total amount of RAM used by this queue
 	Memory int64 `json:"memory"`

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -524,7 +524,7 @@ var _ = Describe("Rabbithole", func() {
 			Ω(q.Name).ShouldNot(Equal(""))
 			Ω(q.Node).ShouldNot(BeNil())
 			Ω(q.Durable).ShouldNot(BeNil())
-			Ω(q.Status).ShouldNot(BeNil())
+			Ω(q.Status).ShouldNot(BeEmpty())
 		})
 	})
 
@@ -561,7 +561,7 @@ var _ = Describe("Rabbithole", func() {
 			Ω(q.Name).ShouldNot(Equal(""))
 			Ω(q.Node).ShouldNot(BeNil())
 			Ω(q.Durable).ShouldNot(BeNil())
-			Ω(q.Status).ShouldNot(BeNil())
+			Ω(q.Status).ShouldNot(BeEmpty())
 			Ω(q.MessagesDetails.Samples[0]).ShouldNot(BeNil())
 		})
 	})
@@ -598,7 +598,7 @@ var _ = Describe("Rabbithole", func() {
 			Ω(q.Name).ShouldNot(Equal(""))
 			Ω(q.Node).ShouldNot(BeNil())
 			Ω(q.Durable).ShouldNot(BeNil())
-			Ω(q.Status).ShouldNot(BeNil())
+			Ω(q.Status).ShouldNot(BeEmpty())
 			Ω(qs.Page).Should(Equal(1))
 			Ω(qs.PageCount).Should(Equal(1))
 			Ω(qs.ItemCount).ShouldNot(BeNil())
@@ -637,7 +637,7 @@ var _ = Describe("Rabbithole", func() {
 			Ω(q.Name).Should(Equal("q2"))
 			Ω(q.Vhost).Should(Equal("rabbit/hole"))
 			Ω(q.Durable).Should(Equal(false))
-			Ω(q.Status).ShouldNot(BeNil())
+			Ω(q.Status).ShouldNot(BeEmpty())
 		})
 	})
 
@@ -668,7 +668,7 @@ var _ = Describe("Rabbithole", func() {
 
 			Ω(q.Vhost).Should(Equal("rabbit/hole"))
 			Ω(q.Durable).Should(Equal(false))
-			Ω(q.Status).ShouldNot(BeNil())
+			Ω(q.Status).ShouldNot(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
Changes the JSON tag for `QueueInfo.Status` field from `status` to `state`. 

Addresses issue presented here: https://github.com/michaelklishin/rabbit-hole/issues/134

