### PR TITLE
PathEscape queue name in ListQueueBindingsBetween

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -150,7 +150,7 @@ func (c *Client) ListExchangeBindingsBetween(vhost, source string, destination s
 //
 
 func (c *Client) ListQueueBindingsBetween(vhost, exchange string, queue string) (rec []BindingInfo, err error) {
-	return c.listBindingsVia("bindings/" + PathEscape(vhost) + "/e/" + PathEscape(exchange) + "/q/" + queue)
+	return c.listBindingsVia("bindings/" + PathEscape(vhost) + "/e/" + PathEscape(exchange) + "/q/" + PathEscape(queue))
 }
 
 //

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -1006,7 +1006,7 @@ var _ = Describe("Rabbithole", func() {
 
 			vh := conn.Config.Vhost
 			x := "test.bindings.x30"
-			q := "test.bindings.q30"
+			q := "test.bindings.q|30"
 
 			err = ch.ExchangeDeclare(x, "topic", false, false, false, false, nil)
 			Ω(err).Should(BeNil())

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -1006,7 +1006,7 @@ var _ = Describe("Rabbithole", func() {
 
 			vh := conn.Config.Vhost
 			x := "test.bindings.x30"
-			q := "test.bindings.q|30"
+			q := "test.bindings.q%7C30"
 
 			err = ch.ExchangeDeclare(x, "topic", false, false, false, false, nil)
 			Ω(err).Should(BeNil())


### PR DESCRIPTION
I discovered that `ListQueueBindingsBetween` would return no error and an empty slice when given a `url.PathEscape`-d queue name.

Now that I'm writing this my test modification is probably not right. I'll see how Travis goes then probably add some `%XY` chars.

Note: the method just above may need that same `PathEscape`.

Also, it's a long long time since go1.8, maybe we could rely on `"net/url"`'s definition of `PathEscape` now?
I can do this in a follow up PR if you want.