### PR TITLE
Add /api/consumers support

### DIFF
--- a/consumers.go
+++ b/consumers.go
@@ -1,0 +1,58 @@
+package rabbithole
+
+import (
+	"net/url"
+)
+
+type BriefQueueInfo struct {
+	Name  string `json:"name"`
+	Vhost string `json:"vhost"`
+}
+
+type BriefChannelDetail struct {
+	ConnectionName string `json:"connection_name"`
+	Name           string `json:"name"`
+	Node           string `json:"node"`
+	Number         int    `json:"number"`
+	PeerHost       string `json:"peer_host"`
+	PeerPort       int    `json:"peer_port"`
+	User           string `json:"user"`
+}
+
+type ConsumerInfo struct {
+	Arguments      map[string]interface{} `json:"arguments"`
+	AckRequired    bool                   `json:"ack_required"`
+	ChannelDetails BriefChannelDetail     `json:"channel_details"`
+	ConsumerTag    string                 `json:"consumer_tag"`
+	Exclusive      bool                   `json:"exclusive"`
+	PrefetchCount  int                    `json:"prefetch_count"`
+	Queue          BriefQueueInfo         `json:"queue"`
+}
+
+// ListConsumers lists all consumers in the cluster.
+func (c *Client) ListConsumers() (rec []ConsumerInfo, err error) {
+	req, err := newGETRequest(c, "consumers")
+	if err != nil {
+		return []ConsumerInfo{}, err
+	}
+
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
+		return []ConsumerInfo{}, err
+	}
+
+	return rec, nil
+}
+
+// ListConsumersIn lists all consumers in a virtual host.
+func (c *Client) ListConsumersIn(vhost string) (rec []ConsumerInfo, err error) {
+	req, err := newGETRequest(c, "consumers/"+url.PathEscape(vhost))
+	if err != nil {
+		return []ConsumerInfo{}, err
+	}
+
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
+		return []ConsumerInfo{}, err
+	}
+
+	return rec, nil
+}

--- a/consumers.go
+++ b/consumers.go
@@ -4,6 +4,13 @@ import (
 	"net/url"
 )
 
+type AcknowledgementMode bool
+
+const (
+	ManualAcknowledgement   AcknowledgementMode = true
+	AutomaticAcknowledgment AcknowledgementMode = false
+)
+
 type BriefQueueInfo struct {
 	Name  string `json:"name"`
 	Vhost string `json:"vhost"`
@@ -20,13 +27,13 @@ type BriefChannelDetail struct {
 }
 
 type ConsumerInfo struct {
-	Arguments      map[string]interface{} `json:"arguments"`
-	AckRequired    bool                   `json:"ack_required"`
-	ChannelDetails BriefChannelDetail     `json:"channel_details"`
-	ConsumerTag    string                 `json:"consumer_tag"`
-	Exclusive      bool                   `json:"exclusive"`
-	PrefetchCount  int                    `json:"prefetch_count"`
-	Queue          BriefQueueInfo         `json:"queue"`
+	Arguments           map[string]interface{} `json:"arguments"`
+	AcknowledgementMode AcknowledgementMode    `json:"ack_required"`
+	ChannelDetails      BriefChannelDetail     `json:"channel_details"`
+	ConsumerTag         string                 `json:"consumer_tag"`
+	Exclusive           bool                   `json:"exclusive"`
+	PrefetchCount       int                    `json:"prefetch_count"`
+	Queue               BriefQueueInfo         `json:"queue"`
 }
 
 // ListConsumers lists all consumers in the cluster.

--- a/consumers.go
+++ b/consumers.go
@@ -33,26 +33,26 @@ type ConsumerInfo struct {
 func (c *Client) ListConsumers() (rec []ConsumerInfo, err error) {
 	req, err := newGETRequest(c, "consumers")
 	if err != nil {
-		return []ConsumerInfo{}, err
+		return
 	}
 
 	if err = executeAndParseRequest(c, req, &rec); err != nil {
-		return []ConsumerInfo{}, err
+		return
 	}
 
-	return rec, nil
+	return
 }
 
 // ListConsumersIn lists all consumers in a virtual host.
 func (c *Client) ListConsumersIn(vhost string) (rec []ConsumerInfo, err error) {
 	req, err := newGETRequest(c, "consumers/"+url.PathEscape(vhost))
 	if err != nil {
-		return []ConsumerInfo{}, err
+		return
 	}
 
 	if err = executeAndParseRequest(c, req, &rec); err != nil {
-		return []ConsumerInfo{}, err
+		return
 	}
 
-	return rec, nil
+	return
 }

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -707,6 +707,92 @@ var _ = Describe("Rabbithole", func() {
 		})
 	})
 
+	Context("GET /consumers", func() {
+		It("returns decoded response", func() {
+			conn := openConnection("/")
+			defer conn.Close()
+
+			ch, err := conn.Channel()
+			Ω(err).Should(BeNil())
+			defer ch.Close()
+
+			_, err = ch.QueueDeclare(
+				"",    // name
+				false, // durable
+				false, // auto delete
+				true,  // exclusive
+				false,
+				nil)
+			Ω(err).Should(BeNil())
+
+			_, err = ch.Consume(
+				"", // queue
+				"", // consumer
+				false, // auto ack
+				false, // exclusive
+				false, // no local
+				false, // no wait
+				amqp.Table{})
+			Ω(err).Should(BeNil())
+
+			// give internal events a moment to be
+			// handled
+			awaitEventPropagation()
+
+			cs, err := rmqc.ListConsumers()
+			Ω(err).Should(BeNil())
+
+			Ω(len(cs)).Should(Equal(1))
+			c := cs[0]
+			Ω(c.Queue.Name).ShouldNot(Equal(""))
+			Ω(c.ConsumerTag).ShouldNot(Equal(""))
+			Ω(c.Exclusive).ShouldNot(BeNil())
+		})
+	})
+
+	Context("GET /consumers/{vhost}", func() {
+		It("returns decoded response", func() {
+			conn := openConnection("rabbit/hole")
+			defer conn.Close()
+
+			ch, err := conn.Channel()
+			Ω(err).Should(BeNil())
+			defer ch.Close()
+
+			_, err = ch.QueueDeclare(
+				"",    // name
+				false, // durable
+				false, // auto delete
+				true,  // exclusive
+				false,
+				nil)
+			Ω(err).Should(BeNil())
+
+			_, err = ch.Consume(
+				"", // queue
+				"", // consumer
+				false, // auto ack
+				false, // exclusive
+				false, // no local
+				false, // no wait
+				amqp.Table{})
+			Ω(err).Should(BeNil())
+
+			// give internal events a moment to be
+			// handled
+			awaitEventPropagation()
+
+			cs, err := rmqc.ListConsumers()
+			Ω(err).Should(BeNil())
+
+			Ω(len(cs)).Should(Equal(1))
+			c := cs[0]
+			Ω(c.Queue.Name).ShouldNot(Equal(""))
+			Ω(c.ConsumerTag).ShouldNot(Equal(""))
+			Ω(c.Exclusive).ShouldNot(BeNil())
+		})
+	})
+
 	Context("GET /users", func() {
 		It("returns decoded response", func() {
 			xs, err := rmqc.ListUsers()

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -747,6 +747,7 @@ var _ = Describe("Rabbithole", func() {
 			Ω(c.Queue.Name).ShouldNot(Equal(""))
 			Ω(c.ConsumerTag).ShouldNot(Equal(""))
 			Ω(c.Exclusive).ShouldNot(BeNil())
+			Ω(c.AcknowledgementMode).Should(Equal(ManualAcknowledgement))
 		})
 	})
 
@@ -771,7 +772,7 @@ var _ = Describe("Rabbithole", func() {
 			_, err = ch.Consume(
 				"", // queue
 				"", // consumer
-				false, // auto ack
+				true, // auto ack
 				false, // exclusive
 				false, // no local
 				false, // no wait
@@ -790,6 +791,7 @@ var _ = Describe("Rabbithole", func() {
 			Ω(c.Queue.Name).ShouldNot(Equal(""))
 			Ω(c.ConsumerTag).ShouldNot(Equal(""))
 			Ω(c.Exclusive).ShouldNot(BeNil())
+			Ω(c.AcknowledgementMode).Should(Equal(AutomaticAcknowledgment))
 		})
 	})
 


### PR DESCRIPTION
This pull request add support for:

- /api/consumers
- /api/consumers/vhost

I added some tests but I'm not that familiars with gomega, so please let me know of anything seems wrong to you.

All the tests are passing.



