### PR TITLE
Fix GetQueue: error while unmarshalling DetailedQueueInfo's OwnerPidDetails

### DIFF
--- a/queues.go
+++ b/queues.go
@@ -106,7 +106,7 @@ type QueueInfo struct {
 
 	MessageStats MessageStats `json:"message_stats"`
 
-	OwnerPidDetails OwnerPidDetails `json:"owner_pid_details"`
+	// OwnerPidDetails OwnerPidDetails `json:"owner_pid_details"`
 
 	BackingQueueStatus BackingQueueStatus `json:"backing_queue_status"`
 

--- a/queues.go
+++ b/queues.go
@@ -37,6 +37,17 @@ type BackingQueueStatus struct {
 	AverageAckEgressRate float32 `json:"avg_ack_egress_rate"`
 }
 
+// OwnerPidDetails cannot be decoded as RMQ sends it as `[]` sometimes.
+// I suspect this means RMQ uses proplists internally instead of maps.
+func (p OwnerPidDetails) UnmarshalJSON(b []byte) error {
+	var l []interface{}
+	if err := json.Unmarshal(b, &l); err == nil && len(l) == 0 {
+		return nil
+	}
+	var o OwnerPidDetails
+	return json.Unmarshal(b, &o)
+}
+
 // OwnerPidDetails describes an exclusive queue owner (connection).
 type OwnerPidDetails struct {
 	Name     string `json:"name"`


### PR DESCRIPTION
For some reason my call to `GetQueue` returns an unmarshalling error because RMQ MGMT returns `[]` instead of a map for the field `owner_pid_details`.

I'm guessing RMQ uses proplists? Any plans on moving to maps?