### PR TITLE
Enable deleting a single exchange's topic permissions

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -195,6 +195,10 @@ Managing Topic Permissions
         resp, err := rmqc.ClearTopicPermissionsIn("/", "my.user")
         // => *http.Response, err
 
+        // revokes single permissions in vhost
+        resp, err := rmqc.DeleteTopicPermissionsIn("/", "my.user", "exchange")
+        // => *http.Response, err
+
 Operations on cluster name
         // Get cluster name
         cn, err := rmqc.GetClusterName()

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -1488,6 +1488,35 @@ var _ = Describe("Rabbithole", func() {
 		})
 	})
 
+	Context("DELETE /topic-permissions/{vhost}/{user}/{exchange}", func() {
+		It("deletes one topic permissions", func() {
+			u := "temporary"
+
+			_, err := rmqc.PutUser(u, UserSettings{Password: "s3krE7"})
+			Ω(err).Should(BeNil())
+
+			awaitEventPropagation()
+			permissions := TopicPermissions{Exchange: "amq.topic", Write: "log.*", Read: "log.*"}
+			_, err = rmqc.UpdateTopicPermissionsIn("/", u, permissions)
+			Ω(err).Should(BeNil())
+			permissions = TopicPermissions{Exchange: "foobar", Write: "log.*", Read: "log.*"}
+			_, err = rmqc.UpdateTopicPermissionsIn("/", u, permissions)
+			Ω(err).Should(BeNil())
+
+			awaitEventPropagation()
+			_, err = rmqc.DeleteTopicPermissionsIn("/", u, "foobar")
+			Ω(err).Should(BeNil())
+
+			awaitEventPropagation()
+			xs, err := rmqc.ListTopicPermissions()
+			Ω(err).Should(BeNil())
+
+			Ω(len(xs)).Should(BeEquivalentTo(1))
+
+			rmqc.DeleteUser(u)
+		})
+	})
+
 	Context("PUT /exchanges/{vhost}/{exchange}", func() {
 		It("declares an exchange", func() {
 			vh := "rabbit/hole"

--- a/topic_permissions.go
+++ b/topic_permissions.go
@@ -120,3 +120,17 @@ func (c *Client) ClearTopicPermissionsIn(vhost, username string) (res *http.Resp
 
 	return res, nil
 }
+
+// DeleteTopicPermissionsIn delete topic-permissions of exchange for user in virtual host.
+func (c *Client) DeleteTopicPermissionsIn(vhost, username string, exchange string) (res *http.Response, err error) {
+	req, err := newRequestWithBody(c, "DELETE", "topic-permissions/"+url.PathEscape(vhost)+"/"+url.PathEscape(username)+"/"+url.PathEscape(exchange), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if res, err = executeRequest(c, req); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
It can be helpful to delete individual topic permissions as well as clearing all of them for a given user.