### PR TITLE
Fix Nil Pointer Dereference on HTTP Client errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -110,6 +110,9 @@ func executeRequest(client *Client, req *http.Request) (res *http.Response, err 
 		httpc.Transport = client.transport
 	}
 	resp, err := httpc.Do(req)
+	if err != nil {
+		return nil, err
+	}
 
 	if resp.StatusCode == 401 {
 		return nil, errors.New("Error: API responded with a 401 Unauthorized")


### PR DESCRIPTION
I just noticed that #145 introduces sefgaults due to nil pointer dereference on HTTP Client errors (e.g., when there's a DNS lookup problem, the server address/port is wrong etc etc). I think we should check `err` before trying to access `resp` which, obviously, can be nil.