### PR TITLE
API for runtime parameters, e.g. for configuring federation upstream components.

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,33 @@ resp, err := rmqc.DeleteShovel("/", "a.shovel")
 
 ```
 
+### Operations on Federation Upstreams
+
+```go
+// list all upstreams
+ups, err := rmqc.ListFederationUpstreams()
+// => []FederationUpstream, error
+
+// list upstreams in a vhost
+ups, err := rmqc.ListFederationUpstreamsIn("/")
+// => []FederationUpstream, error
+
+// information about an upstream
+up, err := rmqc.GetFederationUpstream("/", "upstream-name")
+// => *FederationUpstream, error
+
+// declare an upstream
+resp, err := rmqc.PutFederationUpstream("/", "upstream-name", FederationDefinition{
+  Uri: "amqp://server-name",
+})
+// => *http.Response, error
+
+// delete an upstream
+resp, err := rmqc.DeleteFederationUpstream("/", "upstream-name")
+// => *http.Response, error
+
+```
+
 ### Operations on cluster name
 ``` go
 // Get cluster name

--- a/README.md
+++ b/README.md
@@ -326,29 +326,60 @@ resp, err := rmqc.DeleteShovel("/", "a.shovel")
 
 ```
 
+### Operations on Runtime (vhost-scoped) Parameters
+
+```golang
+// list all runtime parameters
+params, err := rmqc.ListRuntimeParameters()
+// => []RuntimeParameter, error
+
+// list all runtime parameters for a component
+params, err := rmqc.ListRuntimeParametersFor("federation-upstream")
+// => []RuntimeParameter, error
+
+// list runtime parameters in a vhost
+params, err := rmqc.ListRuntimeParametersIn("federation-upstream", "/")
+// => []RuntimeParameter, error
+
+// information about a runtime parameter
+p, err := rmqc.GetRuntimeParameter("federation-upstream", "/", "name")
+// => *RuntimeParameter, error
+
+// declare or update a runtime parameter
+resp, err := rmqc.PutRuntimeParameter("federation-upstream", "/", "name", FederationDefinition{
+    Uri: "amqp://server-name",
+})
+// => *http.Response, error
+
+// remove a runtime parameter
+resp, err := rmqc.DeleteRuntimeParameter("federation-upstream", "/", "name")
+// => *http.Response, error
+
+```
+
 ### Operations on Federation Upstreams
 
-```go
-// list all upstreams
+```golang
+// list all federation upstreams
 ups, err := rmqc.ListFederationUpstreams()
 // => []FederationUpstream, error
 
-// list upstreams in a vhost
+// list federation upstreams in a vhost
 ups, err := rmqc.ListFederationUpstreamsIn("/")
 // => []FederationUpstream, error
 
-// information about an upstream
-up, err := rmqc.GetFederationUpstream("/", "upstream-name")
+// information about a federated upstream
+up, err := rmqc.GetFederationUpstream("/", "name")
 // => *FederationUpstream, error
 
-// declare an upstream
-resp, err := rmqc.PutFederationUpstream("/", "upstream-name", FederationDefinition{
+// declare or update a federation upstream
+resp, err := rmqc.PutFederationUpstream("/", "name", FederationDefinition{
   Uri: "amqp://server-name",
 })
 // => *http.Response, error
 
 // delete an upstream
-resp, err := rmqc.DeleteFederationUpstream("/", "upstream-name")
+resp, err := rmqc.DeleteFederationUpstream("/", "name")
 // => *http.Response, error
 
 ```

--- a/bin/ci/before_build.bat
+++ b/bin/ci/before_build.bat
@@ -25,3 +25,7 @@ call %RABBITHOLE_RABBITMQCTL% set_permissions -p "rabbit/hole" guest ".*" ".*" "
 REM Enable shovel plugin
 call %RABBITHOLE_RABBITMQ_PLUGINS% enable rabbitmq_shovel
 call %RABBITHOLE_RABBITMQ_PLUGINS% enable rabbitmq_shovel_management
+
+REM Enable shovel plugin
+call %RABBITHOLE_RABBITMQ_PLUGINS% enable rabbitmq_federation
+call %RABBITHOLE_RABBITMQ_PLUGINS% enable rabbitmq_federation_management

--- a/bin/ci/before_build.sh
+++ b/bin/ci/before_build.sh
@@ -30,5 +30,6 @@ $CTL set_cluster_name rabbitmq@localhost
 $PLUGINS enable rabbitmq_shovel
 $PLUGINS enable rabbitmq_shovel_management
 
+# Enable federation plugin
 $PLUGINS enable rabbitmq_federation
 $PLUGINS enable rabbitmq_federation_management

--- a/bin/ci/before_build.sh
+++ b/bin/ci/before_build.sh
@@ -29,3 +29,6 @@ $CTL set_cluster_name rabbitmq@localhost
 # Enable shovel plugin
 $PLUGINS enable rabbitmq_shovel
 $PLUGINS enable rabbitmq_shovel_management
+
+$PLUGINS enable rabbitmq_federation
+$PLUGINS enable rabbitmq_federation_management

--- a/doc.go
+++ b/doc.go
@@ -199,21 +199,49 @@ Managing Topic Permissions
         resp, err := rmqc.DeleteTopicPermissionsIn("/", "my.user", "exchange")
         // => *http.Response, err
 
+Managing Runtime Parameters
+
+        // list all runtime parameters
+        params, err := rmqc.ListRuntimeParameters()
+        // => []RuntimeParameter, error
+
+        // list all runtime parameters for a component
+        params, err := rmqc.ListRuntimeParametersFor("federation-upstream")
+        // => []RuntimeParameter, error
+
+        // list runtime parameters in a vhost
+        params, err := rmqc.ListRuntimeParametersIn("federation-upstream", "/")
+        // => []RuntimeParameter, error
+
+        // information about a runtime parameter
+        p, err := rmqc.GetRuntimeParameter("federation-upstream", "/", "name")
+        // => *RuntimeParameter, error
+
+        // declare or update a runtime parameter
+        resp, err := rmqc.PutRuntimeParameter("federation-upstream", "/", "name", FederationDefinition{
+            Uri: "amqp://server-name",
+        })
+        // => *http.Response, error
+
+        // remove a runtime parameter
+        resp, err := rmqc.DeleteRuntimeParameter("federation-upstream", "/", "name")
+        // => *http.Response, error
+
 Managing Federation Upstreams
 
-        // list all upstreams
+        // list all federation upstreams
         ups, err := rmqc.ListFederationUpstreams()
         // => []FederationUpstream, error
 
-        // list upstreams in a vhost
+        // list federation upstreams in a vhost
         ups, err := rmqc.ListFederationUpstreamsIn("/")
         // => []FederationUpstream, error
 
-        // information about an upstream
+        // information about a federated upstream
         up, err := rmqc.GetFederationUpstream("/", "upstream-name")
         // => *FederationUpstream, error
 
-        // declare an upstream
+        // declare or update a federation upstream
         resp, err := rmqc.PutFederationUpstream("/", "upstream-name", FederationDefinition{
           Uri: "amqp://server-name",
         })

--- a/doc.go
+++ b/doc.go
@@ -199,6 +199,30 @@ Managing Topic Permissions
         resp, err := rmqc.DeleteTopicPermissionsIn("/", "my.user", "exchange")
         // => *http.Response, err
 
+Managing Federation Upstreams
+
+        // list all upstreams
+        ups, err := rmqc.ListFederationUpstreams()
+        // => []FederationUpstream, error
+
+        // list upstreams in a vhost
+        ups, err := rmqc.ListFederationUpstreamsIn("/")
+        // => []FederationUpstream, error
+
+        // information about an upstream
+        up, err := rmqc.GetFederationUpstream("/", "upstream-name")
+        // => *FederationUpstream, error
+
+        // declare an upstream
+        resp, err := rmqc.PutFederationUpstream("/", "upstream-name", FederationDefinition{
+          Uri: "amqp://server-name",
+        })
+        // => *http.Response, error
+
+        // delete an upstream
+        resp, err := rmqc.DeleteFederationUpstream("/", "upstream-name")
+        // => *http.Response, error
+
 Operations on cluster name
         // Get cluster name
         cn, err := rmqc.GetClusterName()

--- a/federation.go
+++ b/federation.go
@@ -30,6 +30,15 @@ type FederationUpstream struct {
 	Definition FederationDefinition `json:"value"`
 }
 
+// FederationInfo represents a runtime parameter that targets a "federation-upstream" component.
+// Replaces FederationUpstream and FederationDefinitionDTO
+type FederationInfo struct {
+	Name       string               `json:"name"`
+	Vhost      string               `json:"vhost"`
+	Component  string               `json:"component"`
+	Definition FederationDefinition `json:"value"`
+}
+
 // FederationDefinitionDTO provides a data transfer object for a FederationDefinition.
 type FederationDefinitionDTO struct {
 	Definition FederationDefinition `json:"value"`
@@ -88,6 +97,13 @@ func (c *Client) GetFederationUpstream(vhost, upstreamName string) (rec *Federat
 	}
 
 	return rec, nil
+}
+
+func (c *Client) GetFederationUpstreamV2(vhost, name string) (info *FederationInfo, err error) {
+	if err = c.PopulateRuntimeParameter("federation-upstream", vhost, name, &info); err != nil {
+		return nil, err
+	}
+	return info, nil
 }
 
 //

--- a/federation.go
+++ b/federation.go
@@ -39,7 +39,6 @@ func (c *Client) ListFederationUpstreams() (ups []FederationUpstream, err error)
 		return nil, err
 	}
 
-	ups = []FederationUpstream{}
 	for _, param := range params {
 		up := paramToUpstream(&param)
 		ups = append(ups, *up)
@@ -58,7 +57,6 @@ func (c *Client) ListFederationUpstreamsIn(vhost string) (ups []FederationUpstre
 		return nil, err
 	}
 
-	ups = []FederationUpstream{}
 	for _, param := range params {
 		up := paramToUpstream(&param)
 		ups = append(ups, *up)

--- a/federation.go
+++ b/federation.go
@@ -34,15 +34,15 @@ const FederationUpstreamComponent string = "federation-upstream"
 // GET /api/parameters/federation-upstream
 //
 
-// ListFederationUpstreams returns all federation upstreams
+// ListFederationUpstreams returns a list of all federation upstreams.
 func (c *Client) ListFederationUpstreams() (ups []FederationUpstream, err error) {
 	params, err := c.ListRuntimeParametersFor(FederationUpstreamComponent)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, param := range params {
-		up := paramToUpstream(&param)
+	for _, p := range params {
+		up := paramToUpstream(&p)
 		ups = append(ups, *up)
 	}
 	return ups, nil
@@ -52,15 +52,15 @@ func (c *Client) ListFederationUpstreams() (ups []FederationUpstream, err error)
 // GET /api/parameters/federation-upstream/{vhost}
 //
 
-// ListFederationUpstreamsIn returns all federation upstreams in a vhost
+// ListFederationUpstreamsIn returns a list of all federation upstreams in a vhost.
 func (c *Client) ListFederationUpstreamsIn(vhost string) (ups []FederationUpstream, err error) {
 	params, err := c.ListRuntimeParametersIn(FederationUpstreamComponent, vhost)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, param := range params {
-		up := paramToUpstream(&param)
+	for _, p := range params {
+		up := paramToUpstream(&p)
 		ups = append(ups, *up)
 	}
 	return ups, nil
@@ -70,21 +70,21 @@ func (c *Client) ListFederationUpstreamsIn(vhost string) (ups []FederationUpstre
 // GET /api/parameters/federation-upstream/{vhost}/{upstream}
 //
 
-// GetFederationUpstream returns a federation upstream
+// GetFederationUpstream returns information about a federation upstream.
 func (c *Client) GetFederationUpstream(vhost, name string) (up *FederationUpstream, err error) {
-	param, err := c.GetRuntimeParameter(FederationUpstreamComponent, vhost, name)
+	p, err := c.GetRuntimeParameter(FederationUpstreamComponent, vhost, name)
 	if err != nil {
 		return nil, err
 	}
-	return paramToUpstream(param), nil
+	return paramToUpstream(p), nil
 }
 
 //
 // PUT /api/parameters/federation-upstream/{vhost}/{upstream}
 //
 
-// Updates a federation upstream
-func (c *Client) PutFederationUpstream(vhost string, name string, def FederationDefinition) (res *http.Response, err error) {
+// PutFederationUpstream creates or updates a federation upstream configuration.
+func (c *Client) PutFederationUpstream(vhost, name string, def FederationDefinition) (res *http.Response, err error) {
 	return c.PutRuntimeParameter(FederationUpstreamComponent, vhost, name, def)
 }
 
@@ -92,7 +92,7 @@ func (c *Client) PutFederationUpstream(vhost string, name string, def Federation
 // DELETE /api/parameters/federation-upstream/{vhost}/{name}
 //
 
-// Deletes a federation upstream.
+// DeleteFederationUpstream removes a federation upstream.
 func (c *Client) DeleteFederationUpstream(vhost, name string) (res *http.Response, err error) {
 	return c.DeleteRuntimeParameter(FederationUpstreamComponent, vhost, name)
 }

--- a/federation.go
+++ b/federation.go
@@ -28,6 +28,25 @@ type FederationUpstream struct {
 }
 
 //
+// GET /api/parameters/federation-upstream/{vhost}/{upstream}
+//
+
+// GetFederationUpstream returns a federation upstream
+func (c *Client) GetFederationUpstream(vhost, upstreamName string) (rec *FederationUpstream, err error) {
+	req, err := newGETRequest(c, "parameters/federation-upstream/"+url.PathEscape(vhost)+"/"+url.PathEscape(upstreamName))
+
+	if err != nil {
+		return nil, err
+	}
+
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
+		return nil, err
+	}
+
+	return rec, nil
+}
+
+//
 // PUT /api/parameters/federation-upstream/{vhost}/{upstream}
 //
 

--- a/federation.go
+++ b/federation.go
@@ -28,6 +28,42 @@ type FederationUpstream struct {
 }
 
 //
+// GET /api/parameters/federation-upstream
+//
+
+// ListFederationUpstreams returns all federation upstreams
+func (c *Client) ListFederationUpstreams() (rec []FederationUpstream, err error) {
+	req, err := newGETRequest(c, "parameters/federation-upstream")
+	if err != nil {
+		return []FederationUpstream{}, err
+	}
+
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
+		return []FederationUpstream{}, err
+	}
+
+	return rec, nil
+}
+
+//
+// GET /api/parameters/federation-upstream/{vhost}
+//
+
+// ListFederationUpstreamsIn returns all federation upstreams in a vhost
+func (c *Client) ListFederationUpstreamsIn(vhost string) (rec []FederationUpstream, err error) {
+	req, err := newGETRequest(c, "parameters/federation-upstream/"+url.PathEscape(vhost))
+	if err != nil {
+		return []FederationUpstream{}, err
+	}
+
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
+		return []FederationUpstream{}, err
+	}
+
+	return rec, nil
+}
+
+//
 // GET /api/parameters/federation-upstream/{vhost}/{upstream}
 //
 

--- a/federation.go
+++ b/federation.go
@@ -117,6 +117,10 @@ func (c *Client) PutFederationUpstream(vhost string, upstreamName string, fDef F
 	return res, nil
 }
 
+func (c *Client) PutFederationUpstreamV2(vhost string, name string, def FederationDefinition) (res *http.Response, err error) {
+	return c.PutRuntimeParameter("federation-upstream", vhost, name, def)
+}
+
 //
 // DELETE /api/parameters/federation-upstream/{vhost}/{name}
 //

--- a/federation.go
+++ b/federation.go
@@ -28,13 +28,15 @@ type FederationUpstream struct {
 	Definition FederationDefinition `json:"value"`
 }
 
+const FederationUpstreamComponent string = "federation-upstream"
+
 //
 // GET /api/parameters/federation-upstream
 //
 
 // ListFederationUpstreams returns all federation upstreams
 func (c *Client) ListFederationUpstreams() (ups []FederationUpstream, err error) {
-	params, err := c.ListRuntimeParametersFor("federation-upstream")
+	params, err := c.ListRuntimeParametersFor(FederationUpstreamComponent)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +54,7 @@ func (c *Client) ListFederationUpstreams() (ups []FederationUpstream, err error)
 
 // ListFederationUpstreamsIn returns all federation upstreams in a vhost
 func (c *Client) ListFederationUpstreamsIn(vhost string) (ups []FederationUpstream, err error) {
-	params, err := c.ListRuntimeParametersIn("federation-upstream", vhost)
+	params, err := c.ListRuntimeParametersIn(FederationUpstreamComponent, vhost)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +72,7 @@ func (c *Client) ListFederationUpstreamsIn(vhost string) (ups []FederationUpstre
 
 // GetFederationUpstream returns a federation upstream
 func (c *Client) GetFederationUpstream(vhost, name string) (up *FederationUpstream, err error) {
-	param, err := c.GetRuntimeParameter("federation-upstream", vhost, name)
+	param, err := c.GetRuntimeParameter(FederationUpstreamComponent, vhost, name)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +85,7 @@ func (c *Client) GetFederationUpstream(vhost, name string) (up *FederationUpstre
 
 // Updates a federation upstream
 func (c *Client) PutFederationUpstream(vhost string, name string, def FederationDefinition) (res *http.Response, err error) {
-	return c.PutRuntimeParameter("federation-upstream", vhost, name, def)
+	return c.PutRuntimeParameter(FederationUpstreamComponent, vhost, name, def)
 }
 
 //
@@ -92,7 +94,7 @@ func (c *Client) PutFederationUpstream(vhost string, name string, def Federation
 
 // Deletes a federation upstream.
 func (c *Client) DeleteFederationUpstream(vhost, name string) (res *http.Response, err error) {
-	return c.DeleteRuntimeParameter("federation-upstream", vhost, name)
+	return c.DeleteRuntimeParameter(FederationUpstreamComponent, vhost, name)
 }
 
 // paramToUpstream maps from a RuntimeParameter structure to a FederationUpstream structure.

--- a/federation.go
+++ b/federation.go
@@ -24,6 +24,14 @@ type FederationDefinition struct {
 
 // Represents a configured Federation upstream.
 type FederationUpstream struct {
+	Name       string               `json:"name"`
+	Vhost      string               `json:"vhost"`
+	Component  string               `json:"component"`
+	Definition FederationDefinition `json:"value"`
+}
+
+// FederationDefinitionDTO provides a data transfer object for a FederationDefinition.
+type FederationDefinitionDTO struct {
 	Definition FederationDefinition `json:"value"`
 }
 
@@ -88,10 +96,11 @@ func (c *Client) GetFederationUpstream(vhost, upstreamName string) (rec *Federat
 
 // Updates a federation upstream
 func (c *Client) PutFederationUpstream(vhost string, upstreamName string, fDef FederationDefinition) (res *http.Response, err error) {
-	fedUp := FederationUpstream{
+	fedDTO := FederationDefinitionDTO{
 		Definition: fDef,
 	}
-	body, err := json.Marshal(fedUp)
+
+	body, err := json.Marshal(fedDTO)
 	if err != nil {
 		return nil, err
 	}

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -1848,16 +1848,16 @@ var _ = Describe("Rabbithole", func() {
 
 		Context("when there are upstreams", func() {
 			It("returns the list of upstreams", func() {
-				fd1 := FederationDefinition{
+				def1 := FederationDefinition{
 					Uri: "amqp://server-name/%2f",
 				}
-				_, err := rmqc.PutFederationUpstream("rabbit/hole", "upstream1", fd1)
+				_, err := rmqc.PutFederationUpstream("rabbit/hole", "upstream1", def1)
 				Ω(err).Should(BeNil())
 
-				fd2 := FederationDefinition{
+				def2 := FederationDefinition{
 					Uri: "amqp://example.com/%2f",
 				}
-				_, err = rmqc.PutFederationUpstream("/", "upstream2", fd2)
+				_, err = rmqc.PutFederationUpstream("/", "upstream2", def2)
 				Ω(err).Should(BeNil())
 
 				awaitEventPropagation()
@@ -1894,18 +1894,18 @@ var _ = Describe("Rabbithole", func() {
 			It("returns the list of upstreams", func() {
 				vh := "rabbit/hole"
 
-				fd1 := FederationDefinition{
+				def1 := FederationDefinition{
 					Uri: "amqp://server-name/%2f",
 				}
 
-				_, err := rmqc.PutFederationUpstream(vh, "upstream1", fd1)
+				_, err := rmqc.PutFederationUpstream(vh, "upstream1", def1)
 				Ω(err).Should(BeNil())
 
-				fd2 := FederationDefinition{
+				def2 := FederationDefinition{
 					Uri: "amqp://example.com/%2f",
 				}
 
-				_, err = rmqc.PutFederationUpstream(vh, "upstream2", fd2)
+				_, err = rmqc.PutFederationUpstream(vh, "upstream2", def2)
 				Ω(err).Should(BeNil())
 
 				awaitEventPropagation()
@@ -1943,9 +1943,9 @@ var _ = Describe("Rabbithole", func() {
 				vh := "rabbit/hole"
 				name := "temporary"
 
-				fu, err := rmqc.GetFederationUpstream(vh, name)
+				up, err := rmqc.GetFederationUpstream(vh, name)
 				Ω(err).Should(Equal(ErrorResponse{404, "Object Not Found", "Not Found"}))
-				Ω(fu).Should(BeNil())
+				Ω(up).Should(BeNil())
 			})
 		})
 
@@ -1954,7 +1954,7 @@ var _ = Describe("Rabbithole", func() {
 				vh := "rabbit/hole"
 				name := "temporary"
 
-				fd := FederationDefinition{
+				def := FederationDefinition{
 					Uri:            "amqp://127.0.0.1/%2f",
 					PrefetchCount:  1000,
 					ReconnectDelay: 1,
@@ -1962,21 +1962,21 @@ var _ = Describe("Rabbithole", func() {
 					TrustUserId:    false,
 				}
 
-				_, err := rmqc.PutFederationUpstream(vh, name, fd)
+				_, err := rmqc.PutFederationUpstream(vh, name, def)
 				Ω(err).Should(BeNil())
 
 				awaitEventPropagation()
 
-				fu, err := rmqc.GetFederationUpstream(vh, name)
+				up, err := rmqc.GetFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
-				Ω(fu.Vhost).Should(Equal(vh))
-				Ω(fu.Name).Should(Equal(name))
-				Ω(fu.Component).Should(Equal("federation-upstream"))
-				Ω(fu.Definition.Uri).Should(Equal(fd.Uri))
-				Ω(fu.Definition.PrefetchCount).Should(Equal(fd.PrefetchCount))
-				Ω(fu.Definition.ReconnectDelay).Should(Equal(fd.ReconnectDelay))
-				Ω(fu.Definition.AckMode).Should(Equal(fd.AckMode))
-				Ω(fu.Definition.TrustUserId).Should(Equal(fd.TrustUserId))
+				Ω(up.Vhost).Should(Equal(vh))
+				Ω(up.Name).Should(Equal(name))
+				Ω(up.Component).Should(Equal("federation-upstream"))
+				Ω(up.Definition.Uri).Should(Equal(def.Uri))
+				Ω(up.Definition.PrefetchCount).Should(Equal(def.PrefetchCount))
+				Ω(up.Definition.ReconnectDelay).Should(Equal(def.ReconnectDelay))
+				Ω(up.Definition.AckMode).Should(Equal(def.AckMode))
+				Ω(up.Definition.TrustUserId).Should(Equal(def.TrustUserId))
 
 				_, err = rmqc.DeleteFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
@@ -1990,29 +1990,39 @@ var _ = Describe("Rabbithole", func() {
 				vh := "rabbit/hole"
 				name := "temporary"
 
-				fd := FederationDefinition{
+				def := FederationDefinition{
 					Uri:            "amqp://127.0.0.1/%2f",
+					Expires:        1800000,
+					MessageTTL:     360000,
+					MaxHops:        1,
 					PrefetchCount:  500,
 					ReconnectDelay: 5,
 					AckMode:        "on-publish",
 					TrustUserId:    false,
+					Exchange:       "",
+					Queue:          "",
 				}
 
-				_, err := rmqc.PutFederationUpstream(vh, name, fd)
+				_, err := rmqc.PutFederationUpstream(vh, name, def)
 				Ω(err).Should(BeNil())
 
 				awaitEventPropagation()
 
-				fu, err := rmqc.GetFederationUpstream(vh, name)
+				up, err := rmqc.GetFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
-				Ω(fu.Vhost).Should(Equal(vh))
-				Ω(fu.Name).Should(Equal(name))
-				Ω(fu.Component).Should(Equal("federation-upstream"))
-				Ω(fu.Definition.Uri).Should(Equal(fd.Uri))
-				Ω(fu.Definition.PrefetchCount).Should(Equal(fd.PrefetchCount))
-				Ω(fu.Definition.ReconnectDelay).Should(Equal(fd.ReconnectDelay))
-				Ω(fu.Definition.AckMode).Should(Equal(fd.AckMode))
-				Ω(fu.Definition.TrustUserId).Should(Equal(fd.TrustUserId))
+				Ω(up.Vhost).Should(Equal(vh))
+				Ω(up.Name).Should(Equal(name))
+				Ω(up.Component).Should(Equal("federation-upstream"))
+				Ω(up.Definition.Uri).Should(Equal(def.Uri))
+				Ω(up.Definition.Expires).Should(Equal(def.Expires))
+				Ω(up.Definition.MessageTTL).Should(Equal(def.MessageTTL))
+				Ω(up.Definition.MaxHops).Should(Equal(def.MaxHops))
+				Ω(up.Definition.PrefetchCount).Should(Equal(def.PrefetchCount))
+				Ω(up.Definition.ReconnectDelay).Should(Equal(def.ReconnectDelay))
+				Ω(up.Definition.AckMode).Should(Equal(def.AckMode))
+				Ω(up.Definition.TrustUserId).Should(Equal(def.TrustUserId))
+				Ω(up.Definition.Exchange).Should(Equal(def.Exchange))
+				Ω(up.Definition.Queue).Should(Equal(def.Queue))
 
 				_, err = rmqc.DeleteFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
@@ -2025,7 +2035,7 @@ var _ = Describe("Rabbithole", func() {
 				name := "temporary"
 
 				// create the upstream
-				fd := FederationDefinition{
+				def := FederationDefinition{
 					Uri:            "amqp://127.0.0.1/%2f",
 					PrefetchCount:  1000,
 					ReconnectDelay: 1,
@@ -2033,24 +2043,24 @@ var _ = Describe("Rabbithole", func() {
 					TrustUserId:    false,
 				}
 
-				_, err := rmqc.PutFederationUpstream(vh, name, fd)
+				_, err := rmqc.PutFederationUpstream(vh, name, def)
 				Ω(err).Should(BeNil())
 
 				awaitEventPropagation()
 
-				fu, err := rmqc.GetFederationUpstream(vh, name)
+				up, err := rmqc.GetFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
-				Ω(fu.Vhost).Should(Equal(vh))
-				Ω(fu.Name).Should(Equal(name))
-				Ω(fu.Component).Should(Equal("federation-upstream"))
-				Ω(fu.Definition.Uri).Should(Equal(fd.Uri))
-				Ω(fu.Definition.PrefetchCount).Should(Equal(fd.PrefetchCount))
-				Ω(fu.Definition.ReconnectDelay).Should(Equal(fd.ReconnectDelay))
-				Ω(fu.Definition.AckMode).Should(Equal(fd.AckMode))
-				Ω(fu.Definition.TrustUserId).Should(Equal(fd.TrustUserId))
+				Ω(up.Vhost).Should(Equal(vh))
+				Ω(up.Name).Should(Equal(name))
+				Ω(up.Component).Should(Equal("federation-upstream"))
+				Ω(up.Definition.Uri).Should(Equal(def.Uri))
+				Ω(up.Definition.PrefetchCount).Should(Equal(def.PrefetchCount))
+				Ω(up.Definition.ReconnectDelay).Should(Equal(def.ReconnectDelay))
+				Ω(up.Definition.AckMode).Should(Equal(def.AckMode))
+				Ω(up.Definition.TrustUserId).Should(Equal(def.TrustUserId))
 
 				// update the upstream
-				fd2 := FederationDefinition{
+				def2 := FederationDefinition{
 					Uri:            "amqp://127.0.0.1/%2f",
 					PrefetchCount:  500,
 					ReconnectDelay: 10,
@@ -2058,21 +2068,21 @@ var _ = Describe("Rabbithole", func() {
 					TrustUserId:    true,
 				}
 
-				_, err = rmqc.PutFederationUpstream(vh, name, fd2)
+				_, err = rmqc.PutFederationUpstream(vh, name, def2)
 				Ω(err).Should(BeNil())
 
 				awaitEventPropagation()
 
-				fu2, err := rmqc.GetFederationUpstream(vh, name)
+				up, err = rmqc.GetFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
-				Ω(fu2.Vhost).Should(Equal(vh))
-				Ω(fu2.Name).Should(Equal(name))
-				Ω(fu2.Component).Should(Equal("federation-upstream"))
-				Ω(fu2.Definition.Uri).Should(Equal(fd2.Uri))
-				Ω(fu2.Definition.PrefetchCount).Should(Equal(fd2.PrefetchCount))
-				Ω(fu2.Definition.ReconnectDelay).Should(Equal(fd2.ReconnectDelay))
-				Ω(fu2.Definition.AckMode).Should(Equal(fd2.AckMode))
-				Ω(fu2.Definition.TrustUserId).Should(Equal(fd2.TrustUserId))
+				Ω(up.Vhost).Should(Equal(vh))
+				Ω(up.Name).Should(Equal(name))
+				Ω(up.Component).Should(Equal("federation-upstream"))
+				Ω(up.Definition.Uri).Should(Equal(def2.Uri))
+				Ω(up.Definition.PrefetchCount).Should(Equal(def2.PrefetchCount))
+				Ω(up.Definition.ReconnectDelay).Should(Equal(def2.ReconnectDelay))
+				Ω(up.Definition.AckMode).Should(Equal(def2.AckMode))
+				Ω(up.Definition.TrustUserId).Should(Equal(def2.TrustUserId))
 
 				_, err = rmqc.DeleteFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
@@ -2109,11 +2119,11 @@ var _ = Describe("Rabbithole", func() {
 				vh := "rabbit/hole"
 				name := "temporary"
 
-				fd := FederationDefinition{
+				def := FederationDefinition{
 					Uri: "amqp://127.0.0.1/%2f",
 				}
 
-				_, err := rmqc.PutFederationUpstream(vh, name, fd)
+				_, err := rmqc.PutFederationUpstream(vh, name, def)
 				Ω(err).Should(BeNil())
 
 				awaitEventPropagation()
@@ -2204,68 +2214,6 @@ var _ = Describe("Rabbithole", func() {
 
 				Ω(v["ack-mode"]).Should(Equal(pv["ack-mode"]))
 				Ω(v["trust-user-id"]).Should(Equal(pv["trust-user-id"]))
-
-				_, err = rmqc.DeleteRuntimeParameter(component, vhost, name)
-				Ω(err).Should(BeNil())
-			})
-		})
-	})
-
-	Context("V2 PUT /api/parameters/federation-upstream/{vhost}/{name}", func() {
-		Context("when the parameter does not exist", func() {
-			It("creates the parameter", func() {
-				component := "federation-upstream"
-				vhost := "rabbit/hole"
-				name := "temporary"
-
-				def := FederationDefinition{
-					Uri:            "amqp://127.0.0.1/%2f",
-					PrefetchCount:  1000,
-					ReconnectDelay: 1,
-					AckMode:        "on-confirm",
-					TrustUserId:    false,
-				}
-
-				// use the federation API to create the parameter
-				_, err := rmqc.PutFederationUpstreamV2(vhost, name, def)
-				Ω(err).Should(BeNil())
-
-				awaitEventPropagation()
-
-				// use the runtime parameter API to read the federation info
-				// param is RuntimeParameter
-				param, err := rmqc.GetRuntimeParameter(component, vhost, name)
-
-				Ω(err).Should(BeNil())
-				Ω(param.Component).Should(Equal("federation-upstream"))
-				Ω(param.Vhost).Should(Equal(vhost))
-				Ω(param.Name).Should(Equal(name))
-
-				// the federation defintion is contained in a map
-				v := param.Value.(map[string]interface{})
-				Ω(v["uri"]).Should(Equal(def.Uri))
-
-				// this could be avoided by using decoder.UserNumber()
-				Ω(int(v["prefetch-count"].(float64))).Should(Equal(def.PrefetchCount))
-				Ω(int(v["reconnect-delay"].(float64))).Should(Equal(def.ReconnectDelay))
-
-				Ω(v["ack-mode"]).Should(Equal(def.AckMode))
-				Ω(v["trust-user-id"]).Should(Equal(def.TrustUserId))
-
-				// use the federation API to read the federation info
-				// info is FederationInfo
-				info, err := rmqc.GetFederationUpstreamV2(vhost, name)
-
-				Ω(err).Should(BeNil())
-				Ω(info.Component).Should(Equal(component))
-				Ω(info.Vhost).Should(Equal(vhost))
-				Ω(info.Name).Should(Equal(name))
-
-				Ω(info.Definition.Uri).Should(Equal(def.Uri))
-				Ω(info.Definition.PrefetchCount).Should(Equal(def.PrefetchCount))
-				Ω(info.Definition.ReconnectDelay).Should(Equal(def.ReconnectDelay))
-				Ω(info.Definition.AckMode).Should(Equal(def.AckMode))
-				Ω(info.Definition.TrustUserId).Should(Equal(def.TrustUserId))
 
 				_, err = rmqc.DeleteRuntimeParameter(component, vhost, name)
 				Ω(err).Should(BeNil())

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -137,9 +137,7 @@ var _ = Describe("Rabbithole", func() {
 	Context("GET /api/parameters/federation-upstream/{vhost}", func() {
 		Context("when there are no upstreams", func() {
 			It("returns an empty response", func() {
-				vh := "rabbit/hole"
-
-				list, err := rmqc.ListFederationUpstreamsIn(vh)
+				list, err := rmqc.ListFederationUpstreamsIn("rabbit/hole")
 				Ω(err).Should(BeNil())
 				Ω(list).Should(BeEmpty())
 			})
@@ -279,7 +277,7 @@ var _ = Describe("Rabbithole", func() {
 				vh := "rabbit/hole"
 				name := "temporary"
 
-				// create the initial upstream
+				// create the upstream
 				fd := FederationDefinition{
 					Uri:            "amqp://127.0.0.1/%2f",
 					PrefetchCount:  1000,

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -2252,6 +2252,21 @@ var _ = Describe("Rabbithole", func() {
 				Ω(v["ack-mode"]).Should(Equal(def.AckMode))
 				Ω(v["trust-user-id"]).Should(Equal(def.TrustUserId))
 
+				// use the federation API to read the federation info
+				// info is FederationInfo
+				info, err := rmqc.GetFederationUpstreamV2(vhost, name)
+
+				Ω(err).Should(BeNil())
+				Ω(info.Component).Should(Equal(component))
+				Ω(info.Vhost).Should(Equal(vhost))
+				Ω(info.Name).Should(Equal(name))
+
+				Ω(info.Definition.Uri).Should(Equal(def.Uri))
+				Ω(info.Definition.PrefetchCount).Should(Equal(def.PrefetchCount))
+				Ω(info.Definition.ReconnectDelay).Should(Equal(def.ReconnectDelay))
+				Ω(info.Definition.AckMode).Should(Equal(def.AckMode))
+				Ω(info.Definition.TrustUserId).Should(Equal(def.TrustUserId))
+
 				_, err = rmqc.DeleteRuntimeParameter(component, vhost, name)
 				Ω(err).Should(BeNil())
 			})

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -224,6 +224,9 @@ var _ = Describe("Rabbithole", func() {
 
 				fu, err := rmqc.GetFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
+				Ω(fu.Vhost).Should(Equal(vh))
+				Ω(fu.Name).Should(Equal(name))
+				Ω(fu.Component).Should(Equal("federation-upstream"))
 				Ω(fu.Definition.Uri).Should(Equal(fd.Uri))
 				Ω(fu.Definition.PrefetchCount).Should(Equal(fd.PrefetchCount))
 				Ω(fu.Definition.ReconnectDelay).Should(Equal(fd.ReconnectDelay))
@@ -257,6 +260,9 @@ var _ = Describe("Rabbithole", func() {
 
 				fu, err := rmqc.GetFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
+				Ω(fu.Vhost).Should(Equal(vh))
+				Ω(fu.Name).Should(Equal(name))
+				Ω(fu.Component).Should(Equal("federation-upstream"))
 				Ω(fu.Definition.Uri).Should(Equal(fd.Uri))
 				Ω(fu.Definition.PrefetchCount).Should(Equal(fd.PrefetchCount))
 				Ω(fu.Definition.ReconnectDelay).Should(Equal(fd.ReconnectDelay))
@@ -289,6 +295,9 @@ var _ = Describe("Rabbithole", func() {
 
 				fu, err := rmqc.GetFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
+				Ω(fu.Vhost).Should(Equal(vh))
+				Ω(fu.Name).Should(Equal(name))
+				Ω(fu.Component).Should(Equal("federation-upstream"))
 				Ω(fu.Definition.Uri).Should(Equal(fd.Uri))
 				Ω(fu.Definition.PrefetchCount).Should(Equal(fd.PrefetchCount))
 				Ω(fu.Definition.ReconnectDelay).Should(Equal(fd.ReconnectDelay))
@@ -311,6 +320,9 @@ var _ = Describe("Rabbithole", func() {
 
 				fu2, err := rmqc.GetFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
+				Ω(fu2.Vhost).Should(Equal(vh))
+				Ω(fu2.Name).Should(Equal(name))
+				Ω(fu2.Component).Should(Equal("federation-upstream"))
 				Ω(fu2.Definition.Uri).Should(Equal(fd2.Uri))
 				Ω(fu2.Definition.PrefetchCount).Should(Equal(fd2.PrefetchCount))
 				Ω(fu2.Definition.ReconnectDelay).Should(Equal(fd2.ReconnectDelay))

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -333,6 +333,16 @@ var _ = Describe("Rabbithole", func() {
 				Ω(err).Should(BeNil())
 			})
 		})
+
+		Context("when the upstream definition is bad", func() {
+			It("returns a 400 error response", func() {
+				// this is NOT an err, but a HTTP 400 response
+				resp, err := rmqc.PutFederationUpstream("rabbit/hole", "error", FederationDefinition{})
+				Ω(err).Should(BeNil())
+				Ω(resp.StatusCode).Should(Equal(400))
+				Ω(resp.Status).Should(Equal("400 Bad Request"))
+			})
+		})
 	})
 
 	Context("DELETE /api/parameters/federation-upstream/{vhost}/{name}", func() {
@@ -341,7 +351,7 @@ var _ = Describe("Rabbithole", func() {
 				vh := "rabbit/hole"
 				name := "temporary"
 
-				// this is NOT an error, but a HTTP 404 response
+				// this is NOT an err, but a HTTP 404 response
 				resp, err := rmqc.DeleteFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
 				Ω(resp.StatusCode).Should(Equal(404))

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Rabbithole", func() {
 
 	Context("GET /api/parameters/federation-upstream/{vhost}/{upstream}", func() {
 		Context("when the upstream does not exist", func() {
-			It("returns a 404 error response", func() {
+			It("returns a 404 error", func() {
 				vh := "rabbit/hole"
 				name := "temporary"
 
@@ -217,6 +217,41 @@ var _ = Describe("Rabbithole", func() {
 
 				_, err = rmqc.DeleteFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
+			})
+		})
+	})
+
+	Context("DELETE /api/parameters/federation-upstream/{vhost}/{name}", func() {
+		Context("when the upstream does not exist", func() {
+			It("returns a 404 error response", func() {
+				vh := "rabbit/hole"
+				name := "temporary"
+
+				// this is NOT an error, but a HTTP 404 response
+				resp, err := rmqc.DeleteFederationUpstream(vh, name)
+				Ω(err).Should(BeNil())
+				Ω(resp.StatusCode).Should(Equal(404))
+				Ω(resp.Status).Should(Equal("404 Not Found"))
+			})
+		})
+
+		Context("when the upstream exists", func() {
+			It("deletes the upstream", func() {
+				vh := "rabbit/hole"
+				name := "temporary"
+
+				fd := FederationDefinition{
+					Uri: "amqp://127.0.0.1/%2f",
+				}
+
+				_, err := rmqc.PutFederationUpstream(vh, name, fd)
+				Ω(err).Should(BeNil())
+
+				awaitEventPropagation()
+
+				resp, err := rmqc.DeleteFederationUpstream(vh, name)
+				Ω(err).Should(BeNil())
+				Ω(resp.Status).Should(HavePrefix("20"))
 			})
 		})
 	})

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -2206,7 +2206,6 @@ var _ = Describe("Rabbithole", func() {
 				// we need to convert from interface{}
 				v := p.Value.(map[string]interface{})
 
-				// could use reflect or a better assertion here.
 				Ω(v["uri"]).Should(Equal(pv["uri"]))
 
 				Ω(int(v["prefetch-count"].(float64))).Should(Equal(pv["prefetch-count"]))

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -1971,7 +1971,7 @@ var _ = Describe("Rabbithole", func() {
 				Ω(err).Should(BeNil())
 				Ω(up.Vhost).Should(Equal(vh))
 				Ω(up.Name).Should(Equal(name))
-				Ω(up.Component).Should(Equal("federation-upstream"))
+				Ω(up.Component).Should(Equal(FederationUpstreamComponent))
 				Ω(up.Definition.Uri).Should(Equal(def.Uri))
 				Ω(up.Definition.PrefetchCount).Should(Equal(def.PrefetchCount))
 				Ω(up.Definition.ReconnectDelay).Should(Equal(def.ReconnectDelay))
@@ -2012,7 +2012,7 @@ var _ = Describe("Rabbithole", func() {
 				Ω(err).Should(BeNil())
 				Ω(up.Vhost).Should(Equal(vh))
 				Ω(up.Name).Should(Equal(name))
-				Ω(up.Component).Should(Equal("federation-upstream"))
+				Ω(up.Component).Should(Equal(FederationUpstreamComponent))
 				Ω(up.Definition.Uri).Should(Equal(def.Uri))
 				Ω(up.Definition.Expires).Should(Equal(def.Expires))
 				Ω(up.Definition.MessageTTL).Should(Equal(def.MessageTTL))
@@ -2052,7 +2052,7 @@ var _ = Describe("Rabbithole", func() {
 				Ω(err).Should(BeNil())
 				Ω(up.Vhost).Should(Equal(vh))
 				Ω(up.Name).Should(Equal(name))
-				Ω(up.Component).Should(Equal("federation-upstream"))
+				Ω(up.Component).Should(Equal(FederationUpstreamComponent))
 				Ω(up.Definition.Uri).Should(Equal(def.Uri))
 				Ω(up.Definition.PrefetchCount).Should(Equal(def.PrefetchCount))
 				Ω(up.Definition.ReconnectDelay).Should(Equal(def.ReconnectDelay))
@@ -2077,7 +2077,7 @@ var _ = Describe("Rabbithole", func() {
 				Ω(err).Should(BeNil())
 				Ω(up.Vhost).Should(Equal(vh))
 				Ω(up.Name).Should(Equal(name))
-				Ω(up.Component).Should(Equal("federation-upstream"))
+				Ω(up.Component).Should(Equal(FederationUpstreamComponent))
 				Ω(up.Definition.Uri).Should(Equal(def2.Uri))
 				Ω(up.Definition.PrefetchCount).Should(Equal(def2.PrefetchCount))
 				Ω(up.Definition.ReconnectDelay).Should(Equal(def2.ReconnectDelay))
@@ -2179,7 +2179,7 @@ var _ = Describe("Rabbithole", func() {
 	Context("PUT /api/parameters/{component}/{vhost}/{name}", func() {
 		Context("when the parameter does not exist", func() {
 			It("creates the parameter", func() {
-				component := "federation-upstream"
+				component := FederationUpstreamComponent
 				vhost := "rabbit/hole"
 				name := "temporary"
 
@@ -2199,7 +2199,7 @@ var _ = Describe("Rabbithole", func() {
 				p, err := rmqc.GetRuntimeParameter(component, vhost, name)
 
 				Ω(err).Should(BeNil())
-				Ω(p.Component).Should(Equal("federation-upstream"))
+				Ω(p.Component).Should(Equal(FederationUpstreamComponent))
 				Ω(p.Vhost).Should(Equal(vhost))
 				Ω(p.Name).Should(Equal(name))
 

--- a/runtime_parameters.go
+++ b/runtime_parameters.go
@@ -1,0 +1,138 @@
+package rabbithole
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+)
+
+// RuntimeParameter represents a vhost-scoped parameter.
+type RuntimeParameter struct {
+	Name      string                `json:"name"`
+	Vhost     string                `json:"vhost"`
+	Component string                `json:"component"`
+	Value     RuntimeParameterValue `json:"value"`
+}
+
+// RuntimeParameterValue represents arbitrary parameter data.
+type RuntimeParameterValue map[string]interface{}
+
+//
+// GET /api/parameters
+//
+
+// ListRuntimeParameters returns all runtime parameters.
+func (c *Client) ListRuntimeParameters() (params []RuntimeParameter, err error) {
+	req, err := newGETRequest(c, "parameters")
+	if err != nil {
+		return []RuntimeParameter{}, err
+	}
+
+	if err = executeAndParseRequest(c, req, &params); err != nil {
+		return []RuntimeParameter{}, err
+	}
+
+	return params, nil
+}
+
+//
+// GET /api/parameters/{component}
+//
+
+// ListRuntimeParametersFor returns all runtime parameters for a component in all vhosts.
+func (c *Client) ListRuntimeParametersFor(component string) (params []RuntimeParameter, err error) {
+	req, err := newGETRequest(c, "parameters/"+url.PathEscape(component))
+	if err != nil {
+		return []RuntimeParameter{}, err
+	}
+
+	if err = executeAndParseRequest(c, req, &params); err != nil {
+		return []RuntimeParameter{}, err
+	}
+
+	return params, nil
+}
+
+//
+// GET /api/parameters/{component}/{vhost}
+//
+
+// ListRuntimeParametersIn returns all runtime parameters for a component in a vhost.
+func (c *Client) ListRuntimeParametersIn(component, vhost string) (p []RuntimeParameter, err error) {
+	req, err := newGETRequest(c, "parameters/"+url.PathEscape(component)+"/"+url.PathEscape(vhost))
+	if err != nil {
+		return []RuntimeParameter{}, err
+	}
+
+	if err = executeAndParseRequest(c, req, &p); err != nil {
+		return []RuntimeParameter{}, err
+	}
+
+	return p, nil
+}
+
+//
+// GET /api/parameters/{component}/{vhost}/{name}
+//
+
+// GetRuntimeParameter returns a runtime parameter.
+func (c *Client) GetRuntimeParameter(component, vhost, name string) (p *RuntimeParameter, err error) {
+	req, err := newGETRequest(c, "parameters/"+url.PathEscape(component)+"/"+url.PathEscape(vhost)+"/"+url.PathEscape(name))
+	if err != nil {
+		return nil, err
+	}
+
+	if err = executeAndParseRequest(c, req, &p); err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+//
+// PUT /api/parameters/{component}/{vhost}/{name}
+//
+
+// PutRuntimeParameter creates a runtime parameter.
+func (c *Client) PutRuntimeParameter(component, vhost, name string, value RuntimeParameterValue) (res *http.Response, err error) {
+	param := RuntimeParameter{
+		name,
+		vhost,
+		component,
+		value,
+	}
+
+	body, err := json.Marshal(param)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := newRequestWithBody(c, "PUT", "parameters/"+url.PathEscape(component)+"/"+url.PathEscape(vhost)+"/"+url.PathEscape(name), body)
+	if err != nil {
+		return nil, err
+	}
+
+	if res, err = executeRequest(c, req); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+//
+// DELETE /api/parameters/{component}/{vhost}/{name}
+//
+
+// DeleteRuntimeParameter removes a runtime parameter.
+func (c *Client) DeleteRuntimeParameter(component, vhost, name string) (res *http.Response, err error) {
+	req, err := newRequestWithBody(c, "DELETE", "parameters/"+url.PathEscape(component)+"/"+url.PathEscape(vhost)+"/"+url.PathEscape(name), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if res, err = executeRequest(c, req); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/runtime_parameters.go
+++ b/runtime_parameters.go
@@ -79,16 +79,24 @@ func (c *Client) ListRuntimeParametersIn(component, vhost string) (p []RuntimePa
 
 // GetRuntimeParameter returns a runtime parameter.
 func (c *Client) GetRuntimeParameter(component, vhost, name string) (p *RuntimeParameter, err error) {
+	if err = c.PopulateRuntimeParameter(component, vhost, name, &p); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+// PopulateRuntimeParameter hydrates a runtime parameter using the provided interface.
+func (c *Client) PopulateRuntimeParameter(component, vhost, name string, p interface{}) error {
 	req, err := newGETRequest(c, "parameters/"+url.PathEscape(component)+"/"+url.PathEscape(vhost)+"/"+url.PathEscape(name))
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if err = executeAndParseRequest(c, req, &p); err != nil {
-		return nil, err
+		return err
 	}
 
-	return p, nil
+	return nil
 }
 
 //

--- a/runtime_parameters.go
+++ b/runtime_parameters.go
@@ -79,24 +79,16 @@ func (c *Client) ListRuntimeParametersIn(component, vhost string) (p []RuntimePa
 
 // GetRuntimeParameter returns a runtime parameter.
 func (c *Client) GetRuntimeParameter(component, vhost, name string) (p *RuntimeParameter, err error) {
-	if err = c.PopulateRuntimeParameter(component, vhost, name, &p); err != nil {
-		return nil, err
-	}
-	return p, nil
-}
-
-// PopulateRuntimeParameter hydrates a runtime parameter using the provided interface.
-func (c *Client) PopulateRuntimeParameter(component, vhost, name string, p interface{}) error {
 	req, err := newGETRequest(c, "parameters/"+url.PathEscape(component)+"/"+url.PathEscape(vhost)+"/"+url.PathEscape(name))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err = executeAndParseRequest(c, req, &p); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return p, nil
 }
 
 //

--- a/runtime_parameters.go
+++ b/runtime_parameters.go
@@ -7,11 +7,13 @@ import (
 )
 
 // RuntimeParameter represents a vhost-scoped parameter.
+// Value is interface{} to support creating parameters directly from types such as
+// FederationInfo and ShovelInfo.
 type RuntimeParameter struct {
-	Name      string                `json:"name"`
-	Vhost     string                `json:"vhost"`
-	Component string                `json:"component"`
-	Value     RuntimeParameterValue `json:"value"`
+	Name      string      `json:"name"`
+	Vhost     string      `json:"vhost"`
+	Component string      `json:"component"`
+	Value     interface{} `json:"value"`
 }
 
 // RuntimeParameterValue represents arbitrary parameter data.
@@ -94,7 +96,7 @@ func (c *Client) GetRuntimeParameter(component, vhost, name string) (p *RuntimeP
 //
 
 // PutRuntimeParameter creates a runtime parameter.
-func (c *Client) PutRuntimeParameter(component, vhost, name string, value RuntimeParameterValue) (res *http.Response, err error) {
+func (c *Client) PutRuntimeParameter(component, vhost, name string, value interface{}) (res *http.Response, err error) {
 	param := RuntimeParameter{
 		name,
 		vhost,

--- a/runtime_parameters.go
+++ b/runtime_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // RuntimeParameter represents a vhost-scoped parameter.
 // Value is interface{} to support creating parameters directly from types such as
-// FederationInfo and ShovelInfo.
+// FederationUpstream and ShovelInfo.
 type RuntimeParameter struct {
 	Name      string      `json:"name"`
 	Vhost     string      `json:"vhost"`
@@ -23,7 +23,7 @@ type RuntimeParameterValue map[string]interface{}
 // GET /api/parameters
 //
 
-// ListRuntimeParameters returns all runtime parameters.
+// ListRuntimeParameters returns a list of all runtime parameters.
 func (c *Client) ListRuntimeParameters() (params []RuntimeParameter, err error) {
 	req, err := newGETRequest(c, "parameters")
 	if err != nil {
@@ -41,7 +41,7 @@ func (c *Client) ListRuntimeParameters() (params []RuntimeParameter, err error) 
 // GET /api/parameters/{component}
 //
 
-// ListRuntimeParametersFor returns all runtime parameters for a component in all vhosts.
+// ListRuntimeParametersFor returns a list of all runtime parameters for a component in all vhosts.
 func (c *Client) ListRuntimeParametersFor(component string) (params []RuntimeParameter, err error) {
 	req, err := newGETRequest(c, "parameters/"+url.PathEscape(component))
 	if err != nil {
@@ -59,7 +59,7 @@ func (c *Client) ListRuntimeParametersFor(component string) (params []RuntimePar
 // GET /api/parameters/{component}/{vhost}
 //
 
-// ListRuntimeParametersIn returns all runtime parameters for a component in a vhost.
+// ListRuntimeParametersIn returns a list of all runtime parameters for a component in a vhost.
 func (c *Client) ListRuntimeParametersIn(component, vhost string) (p []RuntimeParameter, err error) {
 	req, err := newGETRequest(c, "parameters/"+url.PathEscape(component)+"/"+url.PathEscape(vhost))
 	if err != nil {
@@ -77,7 +77,7 @@ func (c *Client) ListRuntimeParametersIn(component, vhost string) (p []RuntimePa
 // GET /api/parameters/{component}/{vhost}/{name}
 //
 
-// GetRuntimeParameter returns a runtime parameter.
+// GetRuntimeParameter returns information about a runtime parameter.
 func (c *Client) GetRuntimeParameter(component, vhost, name string) (p *RuntimeParameter, err error) {
 	req, err := newGETRequest(c, "parameters/"+url.PathEscape(component)+"/"+url.PathEscape(vhost)+"/"+url.PathEscape(name))
 	if err != nil {
@@ -95,16 +95,16 @@ func (c *Client) GetRuntimeParameter(component, vhost, name string) (p *RuntimeP
 // PUT /api/parameters/{component}/{vhost}/{name}
 //
 
-// PutRuntimeParameter creates a runtime parameter.
+// PutRuntimeParameter creates or updates a runtime parameter.
 func (c *Client) PutRuntimeParameter(component, vhost, name string, value interface{}) (res *http.Response, err error) {
-	param := RuntimeParameter{
+	p := RuntimeParameter{
 		name,
 		vhost,
 		component,
 		value,
 	}
 
-	body, err := json.Marshal(param)
+	body, err := json.Marshal(p)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What this PR does:
* Adds additional client methods to allow reading of federation upstream parameters.
* Adds tests for all existing and new federation methods.


### Why do we need this PR?
* To add federation support to the [terraform-provider-rabbitmq](https://www.terraform.io/docs/providers/rabbitmq/index.html) terraform provider, we need to be able to read federation upstream resources via the API. I'm working on this now but need these changes before I can continue.

### Notes
Some notes from working on this PR.


#### API changes
To support the new read methods, I added additional fields to `FederationUpstream` and introduced a `FederationDefinitionDTO` type. This is an exact copy of the existing shovel implementation, which makes sense, because they are more or less the same thing.


#### Default values
The only required field for a federation upstream definition is `Uri`. Although many of the other arguments have stated defaults in the docs, when a value is not provided, it gets the default value for the go type instead. 

For example:

```json
// exported configuration for an upstream with only uri provided
{
  "rabbit_version": "3.8.3",
  "parameters": [
    {
      "value": {
        "exchange": "",
        "expires": 0,
        "max-hops": 0,
        "message-ttl": 0,
        "prefetch-count": 0,
        "queue": "",
        "reconnect-delay": 0,
        "trust-user-id": false,
        "uri": "amqp://127.0.0.1/%2f"
      },
      "vhost": "rabbit/hole",
      "component": "federation-upstream",
      "name": "temporary"
    }
  ]
}
```

Is the value for `prefetch-count` the default of `1000`, or `0`? I don't think these values are the same, although I haven't tested this to be honest. It is easy to supply the default values in a request, which is probably the right thing to do. However, some arguments, such as `expires`, use a default value of _none_ (according to the docs) or _leave blank_ (in the Admin UI) to mean _never expires_. Does `0` accomplish the same thing?

Might it be a good idea to annotate these fields with `omitempty` instead?


#### Deleting a federation upstream parameter
Deleting a non-existent upstream returns a `HTTP 404` response and _not_ an `error`. 

```sh
curl -i -u guest:guest \
-X DELETE http://localhost:15672/api/parameters/federation-upstream/rabbit%2fhole/temporary

HTTP/1.1 404 Not Found
content-length: 49
content-security-policy: script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'self'
content-type: application/json
date: Sun, 26 Apr 2020 14:38:08 GMT
server: Cowboy
vary: accept, accept-encoding, origin

{"error":"Object Not Found","reason":"Not Found"}

```

Same for `PutFederationUpstream`. Both methods use the `executeResponse` function, which does not parse the response into an `ErrorResponse{}` error.

This is probably intentional, but I've added tests for these cases in case this logic is ever changed.


#### Additional federation arguments

* The [federation reference docs](https://www.rabbitmq.com/federation-reference.html#upstreams) show an additional federated queue argument called `consumer-tag`.

* The `Admin > Federation Upstreams > Add a new upstream` UI shows an additional federated exchange argument called `ha-policy`.

* The federation plugin [source](https://github.com/rabbitmq/rabbitmq-federation/blob/master/src/rabbit_federation_parameters.erl#L87) shows some additional arguments that may not be documented yet: `resource-cleanup-mode` and `bind-nowait`.

Perhaps the API should support these additional arguments as well?