### PR TITLE
Check RuntimeParameter value before creating FederationUpstream.

### DIFF
--- a/federation.go
+++ b/federation.go
@@ -106,8 +106,12 @@ func paramToUpstream(p *RuntimeParameter) (up *FederationUpstream) {
 		Component: p.Component,
 	}
 
+	m, ok := p.Value.(map[string]interface{})
+	if !ok {
+		return up
+	}
+
 	def := FederationDefinition{}
-	m := p.Value.(map[string]interface{})
 
 	if v, ok := m["uri"].(string); ok {
 		def.Uri = v

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -2270,4 +2270,17 @@ var _ = Describe("Rabbithole", func() {
 			})
 		})
 	})
+
+	Context("paramToUpstream", func() {
+		Context("when the parameter value is not initialized", func() {
+			It("returns an empty FederationUpstream", func() {
+				p := RuntimeParameter{} // p.Value is interface{}
+				up := paramToUpstream(&p)
+				Ω(up.Name).Should(BeEmpty())
+				Ω(up.Vhost).Should(BeEmpty())
+				Ω(up.Component).Should(BeEmpty())
+				Ω(up.Definition).Should(Equal(FederationDefinition{}))
+			})
+		})
+	})
 })

--- a/runtime_parameters.go
+++ b/runtime_parameters.go
@@ -98,10 +98,10 @@ func (c *Client) GetRuntimeParameter(component, vhost, name string) (p *RuntimeP
 // PutRuntimeParameter creates or updates a runtime parameter.
 func (c *Client) PutRuntimeParameter(component, vhost, name string, value interface{}) (res *http.Response, err error) {
 	p := RuntimeParameter{
-		name,
-		vhost,
-		component,
-		value,
+		Name:      name,
+		Vhost:     vhost,
+		Component: component,
+		Value:     value,
 	}
 
 	body, err := json.Marshal(p)


### PR DESCRIPTION
This is a very minor follow-up to https://github.com/michaelklishin/rabbit-hole/pull/150.

### What does this PR do?
* Eliminates possibility (unlikely) of panic in `paramToUpstream` when parameter map is nil.
* Uses consistent format when initializing `RuntimeParameter` structs.

Thanks for all your help with these recent pull requests. I look forward to a new release soon.


