### PR TITLE
Added federation-links endpoints

### DIFF
--- a/federation_links.go
+++ b/federation_links.go
@@ -1,0 +1,39 @@
+package rabbithole
+
+import "net/url"
+
+//
+// GET /api/federation-links
+//
+
+// ListFederationLinks returns a list of all federation links.
+func (c *Client) ListFederationLinks() (links []map[string]interface{}, err error) {
+	req, err := newGETRequest(c, "federation-links")
+	if err != nil {
+		return links, err
+	}
+
+	if err = executeAndParseRequest(c, req, &links); err != nil {
+		return links, err
+	}
+
+	return links, nil
+}
+
+//
+// GET /api/federation-links/{vhost}
+//
+
+// ListFederationLinksIn returns a list of federation links in a vhost.
+func (c *Client) ListFederationLinksIn(vhost string) (links []map[string]interface{}, err error) {
+	req, err := newGETRequest(c, "federation-links/"+url.PathEscape(vhost))
+	if err != nil {
+		return links, err
+	}
+
+	if err = executeAndParseRequest(c, req, &links); err != nil {
+		return links, err
+	}
+
+	return links, nil
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/michaelklishin/rabbit-hole/pull/154

New API calls:
* `GET /api/federation-links`
* `GET /api/federation-links/{vhost}`