### PR TITLE
Add missing Parameters for Shovels

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,17 @@ q, err := rmqc.GetShovel("/", "a.shovel")
 // => ShovelInfo, err
 
 // declares a shovel
-shovelDetails := rabbithole.ShovelDefinition{SourceURI: "amqp://sourceURI", SourceQueue: "mySourceQueue", DestinationURI: "amqp://destinationURI", DestinationQueue: "myDestQueue", AddForwardHeaders: true, AckMode: "on-confirm", DeleteAfter: "never"}
+shovelDetails := rabbithole.ShovelDefinition{
+	SourceURI: "amqp://sourceURI",
+	SourceProtocol: "amqp091",
+	SourceQueue: "mySourceQueue",
+	DestinationURI: "amqp://destinationURI",
+	DestinationProtocol: "amqp10",
+	DestinationAddress: "myDestQueue",
+	DestinationAddForwardHeaders: true,
+	AckMode: "on-confirm",
+	SrcDeleteAfter: "never",
+}
 resp, err := rmqc.DeclareShovel("/", "a.shovel", shovelDetails)
 // => *http.Response, err
 

--- a/shovels.go
+++ b/shovels.go
@@ -20,19 +20,30 @@ type ShovelInfo struct {
 
 // ShovelDefinition contains the details of the shovel configuration
 type ShovelDefinition struct {
-	SourceURI              string `json:"src-uri"`
-	SourceExchange         string `json:"src-exchange,omitempty"`
-	SourceExchangeKey      string `json:"src-exchange-key,omitempty"`
-	SourceQueue            string `json:"src-queue,omitempty"`
-	DestinationURI         string `json:"dest-uri"`
-	DestinationExchange    string `json:"dest-exchange,omitempty"`
-	DestinationExchangeKey string `json:"dest-exchange-key,omitempty"`
-	DestinationQueue       string `json:"dest-queue,omitempty"`
-	PrefetchCount          int    `json:"prefetch-count,omitempty"`
-	ReconnectDelay         int    `json:"reconnect-delay,omitempty"`
-	AddForwardHeaders      bool   `json:"add-forward-headers"`
-	AckMode                string `json:"ack-mode"`
-	DeleteAfter            string `json:"delete-after"`
+	AckMode                          string `json:"ack-mode,omitempty"`
+	AddForwardHeaders                bool   `json:"add-forward-headers,omitempty"`
+	DeleteAfter                      string `json:"delete-after,omitempty"`
+	DestinationAddForwardHeaders     bool   `json:"dest-add-forward-headers,omitempty"`
+	DestinationAddTimestampHeader    bool   `json:"dest-add-timestamp-header,omitempty"`
+	DestinationAddress               string `json:"dest-address,omitempty"`
+	DestinationApplicationProperties string `json:"dest-application-properties,omitempty"`
+	DestinationExchange              string `json:"dest-exchange,omitempty"`
+	DestinationExchangeKey           string `json:"dest-exchange-key,omitempty"`
+	DestinationProperties            string `json:"dest-properties,omitempty"`
+	DestinationProtocol              string `json:"dest-protocol,omitempty"`
+	DestinationPublishProperties     string `json:"dest-publish-properties,omitempty"`
+	DestinationQueue                 string `json:"dest-queue,omitempty"`
+	DestinationURI                   string `json:"dest-uri"`
+	PrefetchCount                    int    `json:"prefetch-count,omitempty"`
+	ReconnectDelay                   int    `json:"reconnect-delay,omitempty"`
+	SourceAddress                    string `json:"src-address,omitempty"`
+	SourceDeleteAfter                string `json:"src-delete-after,omitempty"`
+	SourceExchange                   string `json:"src-exchange,omitempty"`
+	SourceExchangeKey                string `json:"src-exchange-key,omitempty"`
+	SourcePrefetchCount              int    `json:"src-prefetch-count,omitempty"`
+	SourceProtocol                   string `json:"src-protocol,omitempty"`
+	SourceQueue                      string `json:"src-queue,omitempty"`
+	SourceURI                        string `json:"src-uri"`
 }
 
 // ShovelDefinitionDTO provides a data transfer object


### PR DESCRIPTION
Hello,

please consider this pull request which adds the rest of the possible parameters to configure shovels in RMQ. My main use case for this is to be able to use AMQP 1.0 destinations/sources for connections with Azure Event Hub.

thx & best regards,
Andreas