### PR TITLE
Add support for numeric delete-after values

### DIFF
--- a/shovels.go
+++ b/shovels.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"strconv"
 )
 
 // ShovelInfo contains the configuration of a shovel
@@ -18,32 +19,65 @@ type ShovelInfo struct {
 	Definition ShovelDefinition `json:"value"`
 }
 
+// DeleteAfter after can hold a delete-after value which may be a string (eg. "never") or an integer
+type DeleteAfter string
+
+// MarshalJSON can marshal a string or an integer
+func (d DeleteAfter) MarshalJSON() ([]byte, error) {
+	deleteAfterInt, err := strconv.Atoi(string(d))
+	if err != nil {
+		return json.Marshal(string(d))
+	}
+	return json.Marshal(deleteAfterInt)
+}
+
+// UnmarshalJSON can unmarshal a string or an integer
+func (d *DeleteAfter) UnmarshalJSON(b []byte) error {
+	// delete-after is a string, such as "never"
+	if b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		*d = DeleteAfter(s)
+		return nil
+	}
+
+	// delete-after is a number
+	var i int
+	if err := json.Unmarshal(b, &i); err != nil {
+		return err
+	}
+	*d = DeleteAfter(strconv.Itoa(i))
+	return nil
+}
+
 // ShovelDefinition contains the details of the shovel configuration
 type ShovelDefinition struct {
-	AckMode                          string `json:"ack-mode,omitempty"`
-	AddForwardHeaders                bool   `json:"add-forward-headers,omitempty"`
-	DeleteAfter                      string `json:"delete-after,omitempty"`
-	DestinationAddForwardHeaders     bool   `json:"dest-add-forward-headers,omitempty"`
-	DestinationAddTimestampHeader    bool   `json:"dest-add-timestamp-header,omitempty"`
-	DestinationAddress               string `json:"dest-address,omitempty"`
-	DestinationApplicationProperties string `json:"dest-application-properties,omitempty"`
-	DestinationExchange              string `json:"dest-exchange,omitempty"`
-	DestinationExchangeKey           string `json:"dest-exchange-key,omitempty"`
-	DestinationProperties            string `json:"dest-properties,omitempty"`
-	DestinationProtocol              string `json:"dest-protocol,omitempty"`
-	DestinationPublishProperties     string `json:"dest-publish-properties,omitempty"`
-	DestinationQueue                 string `json:"dest-queue,omitempty"`
-	DestinationURI                   string `json:"dest-uri"`
-	PrefetchCount                    int    `json:"prefetch-count,omitempty"`
-	ReconnectDelay                   int    `json:"reconnect-delay,omitempty"`
-	SourceAddress                    string `json:"src-address,omitempty"`
-	SourceDeleteAfter                string `json:"src-delete-after,omitempty"`
-	SourceExchange                   string `json:"src-exchange,omitempty"`
-	SourceExchangeKey                string `json:"src-exchange-key,omitempty"`
-	SourcePrefetchCount              int    `json:"src-prefetch-count,omitempty"`
-	SourceProtocol                   string `json:"src-protocol,omitempty"`
-	SourceQueue                      string `json:"src-queue,omitempty"`
-	SourceURI                        string `json:"src-uri"`
+	AckMode                          string      `json:"ack-mode,omitempty"`
+	AddForwardHeaders                bool        `json:"add-forward-headers,omitempty"`
+	DeleteAfter                      DeleteAfter `json:"delete-after,omitempty"`
+	DestinationAddForwardHeaders     bool        `json:"dest-add-forward-headers,omitempty"`
+	DestinationAddTimestampHeader    bool        `json:"dest-add-timestamp-header,omitempty"`
+	DestinationAddress               string      `json:"dest-address,omitempty"`
+	DestinationApplicationProperties string      `json:"dest-application-properties,omitempty"`
+	DestinationExchange              string      `json:"dest-exchange,omitempty"`
+	DestinationExchangeKey           string      `json:"dest-exchange-key,omitempty"`
+	DestinationProperties            string      `json:"dest-properties,omitempty"`
+	DestinationProtocol              string      `json:"dest-protocol,omitempty"`
+	DestinationPublishProperties     string      `json:"dest-publish-properties,omitempty"`
+	DestinationQueue                 string      `json:"dest-queue,omitempty"`
+	DestinationURI                   string      `json:"dest-uri"`
+	PrefetchCount                    int         `json:"prefetch-count,omitempty"`
+	ReconnectDelay                   int         `json:"reconnect-delay,omitempty"`
+	SourceAddress                    string      `json:"src-address,omitempty"`
+	SourceDeleteAfter                string      `json:"src-delete-after,omitempty"`
+	SourceExchange                   string      `json:"src-exchange,omitempty"`
+	SourceExchangeKey                string      `json:"src-exchange-key,omitempty"`
+	SourcePrefetchCount              int         `json:"src-prefetch-count,omitempty"`
+	SourceProtocol                   string      `json:"src-protocol,omitempty"`
+	SourceQueue                      string      `json:"src-queue,omitempty"`
+	SourceURI                        string      `json:"src-uri"`
 }
 
 // ShovelDefinitionDTO provides a data transfer object


### PR DESCRIPTION
Delete-after can be a string (eg. "never") or an integer. RabbitMQ does
not accept string-formatted integers ("42") so this PR changes the type
of the `DeleteAfter` field and adds a custom marshaler/unmarshaler
to handle both cases. As you can see in the tests, this may be a
breaking change - since values of different types cannot be equal in Go,
when comparing `DeleteAfter` with a string, you now need to convert one of the
values. However, most operations should work without code changes.

Fixes #149