### PR TITLE
Correct Shovel struct field types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/michaelklishin/rabbit-hole/v2
+module github.com/pathcl/rabbit-hole/v2
 
 require (
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pathcl/rabbit-hole/v2
+module github.com/michaelklishin/rabbit-hole/v2
 
 require (
 	github.com/kr/pretty v0.1.0 // indirect

--- a/shovels.go
+++ b/shovels.go
@@ -67,7 +67,7 @@ type ShovelDefinition struct {
 	DestinationProtocol              string      `json:"dest-protocol,omitempty"`
 	DestinationPublishProperties     string      `json:"dest-publish-properties,omitempty"`
 	DestinationQueue                 string      `json:"dest-queue,omitempty"`
-	DestinationURI                   string      `json:"dest-uri"`
+	DestinationURI                   []string    `json:"dest-uri"`
 	PrefetchCount                    int         `json:"prefetch-count,omitempty"`
 	ReconnectDelay                   int         `json:"reconnect-delay,omitempty"`
 	SourceAddress                    string      `json:"src-address,omitempty"`
@@ -77,7 +77,7 @@ type ShovelDefinition struct {
 	SourcePrefetchCount              int         `json:"src-prefetch-count,omitempty"`
 	SourceProtocol                   string      `json:"src-protocol,omitempty"`
 	SourceQueue                      string      `json:"src-queue,omitempty"`
-	SourceURI                        string      `json:"src-uri"`
+	SourceURI                        []string    `json:"src-uri"`
 }
 
 // ShovelDefinitionDTO provides a data transfer object


### PR DESCRIPTION
DestinationURI/SourceURI it's an slice at least in rabbitmq 3.8.9

issue related: https://github.com/michaelklishin/rabbit-hole/issues/103