### PR TITLE
Require source and dest URIs in ShovelDefinition to be collections

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,32 @@
-## Changes Between 2.6.0 and 2.7.0 (under development)
+## Changes Between 2.6.0 and 3.0.0 (under development)
+
+This release contains **minor breaking public API changes**
+and targets RabbitMQ 3.8.x (the only [supported version at the time of wrigin](https://www.rabbitmq.com/versions.html))
+exclusively.
+
+### Support for Lists of Shovel URIs
+
+Shovel definition now uses a dedicated type, ``, to represent
+a set of URIs that will be tried sequentially until the Shovel
+can successfully connect and authenticate:
+
+``` go
+sDef := ShovelDefinition{
+            SourceURI:         ShovelURISet([]string{"amqp://host2/%2f", "amqp://host3/%2f"}),
+            SourceQueue:       "mySourceQueue",
+            DestinationURI:    ShovelURISet([]string{"amqp://host1/%2f"}),
+            DestinationQueue:  "myDestQueue",
+            AddForwardHeaders: true,
+            AckMode:           "on-confirm",
+            DeleteAfter:       "never",
+        }
+```
+
+Source and destination URI sets are only supported by the Shovel plugin in
+RabbitMQ 3.8.x.
+
+Originally suggested by @pathcl in #172.
+
 ### Definition Export
 
 `rabbithole.ListDefinitions` is a new function that retuns

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ This library is a [RabbitMQ HTTP API](https://raw.githack.com/rabbitmq/rabbitmq-
 
 ## Supported Go Versions
 
-Rabbit Hole supports the last 2 stable Go versions, as well as the version in development (a.k.a. master).
+Rabbit Hole targets two latests stable Go versions available at the time of the library release.
+Older versions may work but this is not guaranteed.
 
 
 ## Supported RabbitMQ Versions
 
- * [RabbitMQ `3.8.x`](https://www.rabbitmq.com/changelog.html) is the primary target series
- * Almost all API endpoints work against RabbitMQ `3.7.x` nodes but some metrics and stats may be missing
- * RabbitMQ `3.7.x` is [out of general support](https://www.rabbitmq.com/versions.html)
+ * [RabbitMQ `3.8.x`](https://www.rabbitmq.com/changelog.html) will be the only supported release series starting with Rabbit Hole 3.0
+ * Almost all API operations work against RabbitMQ `3.7.x` nodes. Some metrics and stats may be missing.
+ * RabbitMQ `3.7.x` and older versions are [out of general support](https://www.rabbitmq.com/versions.html)
 
 All versions require [RabbitMQ Management UI plugin](https://www.rabbitmq.com/management.html) to be installed and enabled.
 

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -2398,8 +2398,8 @@ var _ = Describe("Rabbithole", func() {
 			vh := "rabbit/hole"
 			sn := "temporary"
 
-			ssu := "amqp://127.0.0.1/%2f"
-			sdu := "amqp://127.0.0.1/%2f"
+			ssu := ShovelURISet([]string{"amqp://127.0.0.1/%2f"})
+			sdu := ShovelURISet([]string{"amqp://127.0.0.1/%2f", "amqp://localhost/%2f"})
 
 			shovelDefinition := ShovelDefinition{
 				SourceURI:                     ssu,
@@ -2455,8 +2455,8 @@ var _ = Describe("Rabbithole", func() {
 			vh := "rabbit/hole"
 			sn := "temporary"
 
-			ssu := "amqp://127.0.0.1/%2f"
-			sdu := "amqp://127.0.0.1/%2f"
+			ssu := ShovelURISet([]string{"amqp://127.0.0.1/%2f"})
+			sdu := ShovelURISet([]string{"amqp://127.0.0.1/%2f"})
 
 			shovelDefinition := ShovelDefinition{
 				SourceURI:         ssu,
@@ -2501,8 +2501,8 @@ var _ = Describe("Rabbithole", func() {
 			vh := "rabbit/hole"
 			sn := "temporary"
 
-			ssu := "amqp://127.0.0.1/%2f"
-			sdu := "amqp://127.0.0.1/%2f"
+			ssu := ShovelURISet([]string{"amqp://127.0.0.1/%2f"})
+			sdu := ShovelURISet([]string{"amqp://127.0.0.1/%2f"})
 
 			shovelDefinition := ShovelDefinition{
 				SourceURI:         ssu,
@@ -2609,9 +2609,9 @@ var _ = Describe("Rabbithole", func() {
 				Ω(err).Should(BeNil())
 
 				sDef := ShovelDefinition{
-					SourceURI:         "amqp://127.0.0.1/%2f",
+					SourceURI:         ShovelURISet([]string{"amqp://127.0.0.1/%2f"}),
 					SourceQueue:       "mySourceQueue",
-					DestinationURI:    "amqp://127.0.0.1/%2f",
+					DestinationURI:    ShovelURISet([]string{"amqp://127.0.0.1/%2f"}),
 					DestinationQueue:  "myDestQueue",
 					AddForwardHeaders: true,
 					AckMode:           "on-confirm",
@@ -2714,6 +2714,46 @@ var _ = Describe("Rabbithole", func() {
 				}
 			}
 			Ω(foundClusterName).Should(Equal(true))
+		})
+	})
+
+	Context("DeleteAfter marshalling", func() {
+		It("unmarshals DeleteAfter when it is a number", func() {
+			var d DeleteAfter
+			s := []byte("1")
+			err := d.UnmarshalJSON(s)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			Ω(d).Should(Equal(DeleteAfter("1")))
+		})
+
+		It("unmarshals DeleteAfter when it is a quoted string", func() {
+			var d DeleteAfter
+			s := []byte("\"3\"")
+			err := d.UnmarshalJSON(s)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			Ω(d).Should(Equal(DeleteAfter("3")))
+		})
+	})
+
+	Context("ShovelURISet marshalling", func() {
+		It("unmarshals a single string", func() {
+			var us ShovelURISet
+			bs := []byte("\"amqp://127.0.0.1:5672\"")
+			err := us.UnmarshalJSON(bs)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			Ω(us).Should(Equal(ShovelURISet([]string{"amqp://127.0.0.1:5672"})))
+		})
+
+		It("unmarshals a list of strings", func() {
+			var us ShovelURISet
+			bs := []byte("[\"amqp://127.0.0.1:5672\", \"amqp://localhost:5672\"]")
+			err := us.UnmarshalJSON(bs)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			Ω(us).Should(Equal(ShovelURISet([]string{"amqp://127.0.0.1:5672", "amqp://localhost:5672"})))
 		})
 	})
 })

--- a/shovels.go
+++ b/shovels.go
@@ -52,8 +52,38 @@ func (d *DeleteAfter) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// ShovelURISet represents a set of URIs used by Shovel.
+// The URIs from this set are tried until one of them succeeds
+// (Shovel successfully connects and authenticates with it)
+type ShovelURISet []string
+
+// UnmarshalJSON can unmarshal a single URI string or a list of
+// URI strings
+func (s *ShovelURISet) UnmarshalJSON(b []byte) error {
+	// the value is a single URI, a string
+	if b[0] == '"' {
+		var uri string
+		if err := json.Unmarshal(b, &uri); err != nil {
+			return err
+		}
+		*s = ShovelURISet([]string{uri})
+		return nil
+	}
+
+	// the value is a list
+	var uris []string
+	if err := json.Unmarshal(b, &uris); err != nil {
+		return err
+	}
+	*s = ShovelURISet(uris)
+	return nil
+}
+
 // ShovelDefinition contains the details of the shovel configuration
 type ShovelDefinition struct {
+	DestinationURI ShovelURISet `json:"dest-uri"`
+	SourceURI      ShovelURISet `json:"src-uri"`
+
 	AckMode                          string      `json:"ack-mode,omitempty"`
 	AddForwardHeaders                bool        `json:"add-forward-headers,omitempty"`
 	DeleteAfter                      DeleteAfter `json:"delete-after,omitempty"`
@@ -67,7 +97,6 @@ type ShovelDefinition struct {
 	DestinationProtocol              string      `json:"dest-protocol,omitempty"`
 	DestinationPublishProperties     string      `json:"dest-publish-properties,omitempty"`
 	DestinationQueue                 string      `json:"dest-queue,omitempty"`
-	DestinationURI                   string      `json:"dest-uri"`
 	PrefetchCount                    int         `json:"prefetch-count,omitempty"`
 	ReconnectDelay                   int         `json:"reconnect-delay,omitempty"`
 	SourceAddress                    string      `json:"src-address,omitempty"`
@@ -77,7 +106,6 @@ type ShovelDefinition struct {
 	SourcePrefetchCount              int         `json:"src-prefetch-count,omitempty"`
 	SourceProtocol                   string      `json:"src-protocol,omitempty"`
 	SourceQueue                      string      `json:"src-queue,omitempty"`
-	SourceURI                        string      `json:"src-uri"`
 }
 
 // ShovelDefinitionDTO provides a data transfer object


### PR DESCRIPTION
This is a 3.8-specific API endpoint feature but we still
support deserialization of 3.7 responses.

Closes #103, #172.