### PR TITLE
Fix type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/michaelklishin/rabbit-hole/v2
+module github.com/Serviceware/rabbit-hole/v2
 
 require (
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Serviceware/rabbit-hole/v2
+module github.com/michaelklishin/rabbit-hole/v2
 
 require (
 	github.com/kr/pretty v0.1.0 // indirect

--- a/health_checks.go
+++ b/health_checks.go
@@ -100,7 +100,7 @@ type PortListenerCheckStatus struct {
 	Status  string `json:"status"`
 	Reason  string `json:"reason,omitempty"`
 	Port    uint   `json:"port,omitempty"`
-	Missing string `json:"missing,omitempty"`
+	Missing uint   `json:"missing,omitempty"`
 	Ports   []uint `json:"ports,omitempty"`
 }
 


### PR DESCRIPTION
Type for field Missing must not be string because api reponse is an integer:

```
$ curl -i -u monitoring:secret "http://localhost:15672/api/health/checks/port-listener/5671"                                                             


HTTP/1.1 503 Service Unavailable
cache-control: no-cache
content-length: 97
content-security-policy: script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'self'
content-type: application/json
date: Mon, 01 Feb 2021 12:49:30 GMT
server: Cowboy
vary: accept, accept-encoding, origin

{"status":"failed","reason":"No active listener","missing":5671,"ports":[15672,15692,25672,5672]}
```