### PR TITLE
Optional parameters of FederationDefinition are now marked with `omitempty` to prevent zero values from being sent to the API.

### DIFF
--- a/federation.go
+++ b/federation.go
@@ -10,13 +10,13 @@ type FederationDefinition struct {
 	Uri            string `json:"uri"`
 	Expires        int    `json:"expires,omitempty"`
 	MessageTTL     int32  `json:"message-ttl"`
-	MaxHops        int    `json:"max-hops"`
-	PrefetchCount  int    `json:"prefetch-count"`
+	MaxHops        int    `json:"max-hops,omitempty"`
+	PrefetchCount  int    `json:"prefetch-count,omitempty"`
 	ReconnectDelay int    `json:"reconnect-delay"`
 	AckMode        string `json:"ack-mode,omitempty"`
 	TrustUserId    bool   `json:"trust-user-id"`
-	Exchange       string `json:"exchange"`
-	Queue          string `json:"queue"`
+	Exchange       string `json:"exchange,omitempty"`
+	Queue          string `json:"queue,omitempty"`
 }
 
 // FederationUpstream represents a configured federation upstream.


### PR DESCRIPTION
The following parameters are optional in the RabbitMQ API and may be absent in the request body. The API treats the zero-values (an empty string, for example) differently than the absence of such value. This causes the created configuration to be incorrect in some cases.

My particular use-case was to create a federation upstream without the defined exchange or queue name. However, the request generated by rabbit-hole sent those parameters as empty strings, which caused the upstream client to connect to a queue with the name `''` (queue name is mandatory, so such queue cannot exist anyway). Instead, I wanted to get the default behaviour in which any downstream queue would be federated with an upstream queue with the same name.