### PR TITLE
Add support for global parameters 🐰

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,27 @@ resp, err := rmqc.DeleteFederationUpstream("/", "name")
 
 ```
 
+### Managing Global Parameters
+``` go
+// list all global parameters
+params, err := rmqc.ListGlobalParameters()
+// => []GlobalRuntimeParameter, error
+
+// get a global parameter
+p, err := rmqc.GetGlobalParameter("name")
+// => *GlobalRuntimeParameter, error
+
+// declare or update a global parameter
+resp, err := rmqc.PutGlobalParameter("name", map[string]interface{
+    endpoints: "amqp://server-name",
+})
+// => *http.Response, error
+
+// delete a global parameter
+resp, err := rmqc.DeleteGlobalParameter("name")
+// => *http.Response, error
+```
+
 ### Operations on cluster name
 ``` go
 // Get cluster name

--- a/doc.go
+++ b/doc.go
@@ -251,6 +251,26 @@ Managing Federation Upstreams
         resp, err := rmqc.DeleteFederationUpstream("/", "upstream-name")
         // => *http.Response, error
 
+Managing Global Parameters
+
+        // list all global parameters
+        params, err := rmqc.ListGlobalParameters()
+        // => []GlobalRuntimeParameter, error
+
+        // get a global parameter
+        p, err := rmqc.GetGlobalParameter("name")
+        // => *GlobalRuntimeParameter, error
+
+        // declare or update a global parameter
+        resp, err := rmqc.PutGlobalParameter("name", map[string]interface{
+            endpoints: "amqp://server-name",
+        })
+        // => *http.Response, error
+
+        // delete a global parameter
+        resp, err := rmqc.DeleteGlobalParameter("name")
+        // => *http.Response, error
+
 Operations on cluster name
         // Get cluster name
         cn, err := rmqc.GetClusterName()

--- a/global_parameters.go
+++ b/global_parameters.go
@@ -1,0 +1,99 @@
+package rabbithole
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+)
+
+// GlobalRuntimeParameter represents a vhost-scoped parameter.
+// Value is interface{} to support creating parameters directly from types such as
+// FederationUpstream and ShovelInfo.
+type GlobalRuntimeParameter struct {
+	Name  string      `json:"name"`
+	Value interface{} `json:"value"`
+}
+
+
+//
+// GET /api/global-parameters
+//
+
+// ListGlobalParameters returns a list of all global parameters.
+func (c *Client) ListGlobalParameters() (params []GlobalRuntimeParameter, err error) {
+	req, err := newGETRequest(c, "global-parameters")
+	if err != nil {
+		return []GlobalRuntimeParameter{}, err
+	}
+
+	if err = executeAndParseRequest(c, req, &params); err != nil {
+		return []GlobalRuntimeParameter{}, err
+	}
+
+	return params, nil
+}
+
+//
+// GET /api/global-parameters/name
+//
+
+// GetGlobalParameter returns information about a global parameter.
+func (c *Client) GetGlobalParameter(name string) (p *GlobalRuntimeParameter, err error) {
+	req, err := newGETRequest(c, "global-parameters/"+url.PathEscape(name))
+	if err != nil {
+		return nil, err
+	}
+
+	if err = executeAndParseRequest(c, req, &p); err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+//
+// PUT /api/global-parameters/name/{value}
+//
+
+// PutRuntimeParameter creates or updates a runtime parameter.
+func (c *Client) PutGlobalParameter(name string, value interface{}) (res *http.Response, err error) {
+	p := GlobalRuntimeParameter{
+		Name:      name,
+		Value:     value,
+	}
+
+	body, err := json.Marshal(p)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := newRequestWithBody(c, "PUT", "global-parameters/"+url.PathEscape(name), body)
+	if err != nil {
+		return nil, err
+	}
+
+	if res, err = executeRequest(c, req); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+//
+// DELETE /api/global-parameters/name
+//
+
+// DeleteRuntimeParameter removes a runtime parameter.
+func (c *Client) DeleteGlobalParameter(name string) (res *http.Response, err error) {
+	req, err := newRequestWithBody(c, "DELETE", "global-parameters/"+url.PathEscape(name), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if res, err = executeRequest(c, req); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+

--- a/runtime_parameters.go
+++ b/runtime_parameters.go
@@ -19,14 +19,6 @@ type RuntimeParameter struct {
 // RuntimeParameterValue represents arbitrary parameter data.
 type RuntimeParameterValue map[string]interface{}
 
-// GlobalRuntimeParameter represents a vhost-scoped parameter.
-// Value is interface{} to support creating parameters directly from types such as
-// FederationUpstream and ShovelInfo.
-type GlobalRuntimeParameter struct {
-	Name  string      `json:"name"`
-	Value interface{} `json:"value"`
-}
-
 //
 // GET /api/parameters
 //


### PR DESCRIPTION
Adding functions to manage global parameters:

- `ListGlobalParameters()`
- `GetGlobalParameter()`
- `PutGlobalParameter()`
- `DeleteGlobalParameter()`

Will be used in topology operator to set global parameter`schema_replication_upstream_endpoints` for schema replication (currently done by `rabbitmqctl set_schema_replication_upstream_endpoints`). 