### PR TITLE
Support Internal Exchanges

### DIFF
--- a/exchanges.go
+++ b/exchanges.go
@@ -38,6 +38,7 @@ type ExchangeSettings struct {
 	Type       string                 `json:"type"`
 	Durable    bool                   `json:"durable"`
 	AutoDelete bool                   `json:"auto_delete,omitempty"`
+	Internal   bool                   `json:"internal,omitempty"`
 	Arguments  map[string]interface{} `json:"arguments,omitempty"`
 }
 


### PR DESCRIPTION
Add support for internal exchanges.

Although #130 was closed when it was request, our use case (rabbitmq terraform provider configuration) we require exchanges to ensure applications do not publish to these exchanges.