### PR TITLE
Set queue type in queue argument if it's set in QueueSettings

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -212,7 +212,7 @@ func (c *Client) newBindingPath(vhost string, info BindingInfo) string {
 // DELETE /api/bindings/{vhost}/e/{source}/{destination_type}/{destination}/{props}
 //
 
-// DeleteBinding delets an individual binding
+// DeleteBinding deletes an individual binding
 func (c *Client) DeleteBinding(vhost string, info BindingInfo) (res *http.Response, err error) {
 	req, err := newRequestWithBody(c, "DELETE", "bindings/"+url.PathEscape(vhost)+
 		"/e/"+url.PathEscape(info.Source)+"/"+url.PathEscape(string(info.DestinationType[0]))+

--- a/queues.go
+++ b/queues.go
@@ -52,7 +52,7 @@ type QueueInfo struct {
 	Vhost string `json:"vhost"`
 	// Is this queue durable?
 	Durable bool `json:"durable"`
-	// Is this queue auto-delted?
+	// Is this queue auto-deleted?
 	AutoDelete bool `json:"auto_delete"`
 	// Extra queue arguments
 	Arguments map[string]interface{} `json:"arguments"`
@@ -300,6 +300,11 @@ func (c *Client) DeclareQueue(vhost, queue string, info QueueSettings) (res *htt
 	if info.Arguments == nil {
 		info.Arguments = make(map[string]interface{})
 	}
+	
+	if info.Type != "" {
+		info.Arguments["x-queue-type"] = info.Type
+	}
+
 	body, err := json.Marshal(info)
 	if err != nil {
 		return nil, err

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -2377,7 +2377,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 				Ω(len(list)).Should(Equal(1))
 				Ω(err).Should(BeNil())
 
-				var link map[string]interface{} = list[0]
+				var link = list[0]
 				Ω(link["vhost"]).Should(Equal(vhost))
 				Ω(link["upstream"]).Should(Equal(upstreamName))
 				Ω(link["type"]).Should(Equal("exchange"))

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -1634,18 +1634,19 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 	Context("PUT /queues/{vhost}/{queue}", func() {
 		It("declares a queue", func() {
 			vh := "rabbit/hole"
-			qn := "temporary"
+			qn := "temporary-declare"
 
-			_, err := rmqc.DeclareQueue(vh, qn, QueueSettings{Durable: false})
+			_, err := rmqc.DeclareQueue(vh, qn, QueueSettings{Durable: true, Type: "quorum"})
 			Ω(err).Should(BeNil())
 
 			awaitEventPropagation()
 			x, err := rmqc.GetQueue(vh, qn)
 			Ω(err).Should(BeNil())
 			Ω(x.Name).Should(Equal(qn))
-			Ω(x.Durable).Should(Equal(false))
+			Ω(x.Durable).Should(Equal(true))
 			Ω(x.AutoDelete).Should(Equal(false))
 			Ω(x.Vhost).Should(Equal(vh))
+			Ω(x.Arguments).To(HaveKeyWithValue("x-queue-type", "quorum"))
 
 			_, err = rmqc.DeleteQueue(vh, qn)
 			Ω(err).Should(BeNil())

--- a/shovels.go
+++ b/shovels.go
@@ -80,7 +80,7 @@ func (s *ShovelURISet) UnmarshalJSON(b []byte) error {
 		if err := json.Unmarshal(b, &uri); err != nil {
 			return err
 		}
-		*s = ShovelURISet([]string{uri})
+		*s = []string{uri}
 		return nil
 	}
 
@@ -89,7 +89,7 @@ func (s *ShovelURISet) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &uris); err != nil {
 		return err
 	}
-	*s = ShovelURISet(uris)
+	*s = uris
 	return nil
 }
 

--- a/topic_permissions.go
+++ b/topic_permissions.go
@@ -15,7 +15,7 @@ type TopicPermissionInfo struct {
 	User  string `json:"user"`
 	Vhost string `json:"vhost"`
 
-	// Configuration topic-permisions
+	// Configuration topic-permissions
 	Exchange string `json:"exchange"`
 	// Write topic-permissions
 	Write string `json:"write"`

--- a/unit_test.go
+++ b/unit_test.go
@@ -7,7 +7,7 @@ import (
 
 var _ = Describe("Unit tests", func() {
 	Context("DeleteAfter marshalling", func() {
-		It("unmarshals DeleteAfter when it is a number", func() {
+		It("unmarshalls DeleteAfter when it is a number", func() {
 			var d DeleteAfter
 			s := []byte("1")
 			err := d.UnmarshalJSON(s)
@@ -16,7 +16,7 @@ var _ = Describe("Unit tests", func() {
 			Ω(d).Should(Equal(DeleteAfter("1")))
 		})
 
-		It("unmarshals DeleteAfter when it is a quoted string", func() {
+		It("unmarshalls DeleteAfter when it is a quoted string", func() {
 			var d DeleteAfter
 			s := []byte("\"3\"")
 			err := d.UnmarshalJSON(s)
@@ -27,7 +27,7 @@ var _ = Describe("Unit tests", func() {
 	})
 
 	Context("ShovelURISet marshalling", func() {
-		It("unmarshals a single string", func() {
+		It("unmarshalls a single string", func() {
 			var us ShovelURISet
 			bs := []byte("\"amqp://127.0.0.1:5672\"")
 			err := us.UnmarshalJSON(bs)
@@ -36,7 +36,7 @@ var _ = Describe("Unit tests", func() {
 			Ω(us).Should(Equal(ShovelURISet([]string{"amqp://127.0.0.1:5672"})))
 		})
 
-		It("unmarshals a list of strings", func() {
+		It("unmarshalls a list of strings", func() {
 			var us ShovelURISet
 			bs := []byte("[\"amqp://127.0.0.1:5672\", \"amqp://localhost:5672\"]")
 			err := us.UnmarshalJSON(bs)

--- a/users.go
+++ b/users.go
@@ -52,7 +52,7 @@ func (d *UserTags) UnmarshalJSON(b []byte) error {
 		for _, qt := range quotedTags {
 			tags = append(tags, qt)
 		}
-		*d = UserTags(tags)
+		*d = tags
 		return nil
 	}
 	// the value is an array
@@ -60,7 +60,7 @@ func (d *UserTags) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &ary); err != nil {
 		return err
 	}
-	*d = UserTags(ary)
+	*d = ary
 	return nil
 }
 

--- a/users.go
+++ b/users.go
@@ -48,7 +48,7 @@ func (d *UserTags) UnmarshalJSON(b []byte) error {
 	t, _ := strconv.Unquote(string(b))
 	if b[0] == '"' {
 		quotedTags := strings.Split(t, ",")
-		tags := []string{}
+		var tags []string
 		for _, qt := range quotedTags {
 			tags = append(tags, qt)
 		}

--- a/vhosts.go
+++ b/vhosts.go
@@ -107,7 +107,7 @@ func (d *VhostTags) UnmarshalJSON(b []byte) error {
 		for _, qt := range quotedTags {
 			tags = append(tags, qt)
 		}
-		*d = VhostTags(tags)
+		*d = tags
 		return nil
 	}
 	// the value is an array
@@ -115,7 +115,7 @@ func (d *VhostTags) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &ary); err != nil {
 		return err
 	}
-	*d = VhostTags(ary)
+	*d = ary
 	return nil
 }
 

--- a/vhosts.go
+++ b/vhosts.go
@@ -103,7 +103,7 @@ func (d *VhostTags) UnmarshalJSON(b []byte) error {
 	t, _ := strconv.Unquote(string(b))
 	if b[0] == '"' {
 		quotedTags := strings.Split(t, ",")
-		tags := []string{}
+		var tags []string
 		for _, qt := range quotedTags {
 			tags = append(tags, qt)
 		}


### PR DESCRIPTION
**Summary**

At the moment, setting `QueueSettings.Type` when calling `DeclareQueue` does not do anything. This change sets queue argument `x-queue-type` to the value of`QueueSettings.Type` (if present). Took inspiration from: https://github.com/rabbitmq/rabbitmq-management/pull/762/files

Some small refactoring on typos and redundant type conversion. 

Thanks @mkuratczyk for looking at this together with me 😄 