### PR TITLE
ShovelDefinition.SourceDeleteAfter should be type 'DeleteAfter'

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ q, err := rmqc.GetShovel("/", "a.shovel")
 
 // declares a shovel
 shovelDetails := rabbithole.ShovelDefinition{
-	SourceURI: "amqp://sourceURI",
+	SourceURI: URISet{"amqp://sourceURI"},
 	SourceProtocol: "amqp091",
 	SourceQueue: "mySourceQueue",
 	DestinationURI: "amqp://destinationURI",
@@ -375,7 +375,7 @@ p, err := rmqc.GetRuntimeParameter("federation-upstream", "/", "name")
 
 // declare or update a runtime parameter
 resp, err := rmqc.PutRuntimeParameter("federation-upstream", "/", "name", FederationDefinition{
-    Uri: "amqp://server-name",
+    Uri: URISet{"amqp://server-name"},
 })
 // => *http.Response, error
 
@@ -402,7 +402,7 @@ up, err := rmqc.GetFederationUpstream("/", "name")
 
 // declare or update a federation upstream
 resp, err := rmqc.PutFederationUpstream("/", "name", FederationDefinition{
-  Uri: "amqp://server-name",
+  Uri: URISet{"amqp://server-name"},
 })
 // => *http.Response, error
 

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -2682,7 +2682,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 			Ω(x.Definition.DestinationAddForwardHeaders).Should(Equal(true))
 			Ω(x.Definition.DestinationAddTimestampHeader).Should(Equal(true))
 			Ω(x.Definition.AckMode).Should(Equal("on-confirm"))
-			Ω(x.Definition.SourceDeleteAfter).Should(Equal("never"))
+			Ω(string(x.Definition.SourceDeleteAfter)).Should(Equal("never"))
 
 			_, err = rmqc.DeleteShovel(vh, sn)
 			Ω(err).Should(BeNil())

--- a/shovels.go
+++ b/shovels.go
@@ -87,7 +87,7 @@ type ShovelDefinition struct {
 	PrefetchCount                    int         `json:"prefetch-count,omitempty"`
 	ReconnectDelay                   int         `json:"reconnect-delay,omitempty"`
 	SourceAddress                    string      `json:"src-address,omitempty"`
-	SourceDeleteAfter                string      `json:"src-delete-after,omitempty"`
+	SourceDeleteAfter                DeleteAfter `json:"src-delete-after,omitempty"`
 	SourceExchange                   string      `json:"src-exchange,omitempty"`
 	SourceExchangeKey                string      `json:"src-exchange-key,omitempty"`
 	SourcePrefetchCount              int         `json:"src-prefetch-count,omitempty"`


### PR DESCRIPTION
## Changes
- ShovelDefinition.SourceDeleteAfter should be the same type as ShovelDefinition.DeleteAfter
- Update types for FederationDefinition and ShovelDefinition URI in README