### PR TITLE
add more fields of metrics in NodeInfo and QueueInfo

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -7,11 +7,6 @@ import (
 // OsPid is an operating system process ID.
 type OsPid string
 
-// NodeMetricDetails .
-type NodeMetricDetails struct {
-	Rate float64 `rate`
-}
-
 // NameDescriptionEnabled represents a named entity with a description.
 type NameDescriptionEnabled struct {
 	Name        string `json:"name"`
@@ -50,10 +45,10 @@ type ClusterLink struct {
 
 // ClusterLinkStats is a stats field in ClusterLink
 type ClusterLinkStats struct {
-	SendBytes        uint64            `json:"send_bytes"`
-	SendBytesDetails NodeMetricDetails `json:"send_bytes_details"`
-	RecvBytes        uint64            `json:"recv_bytes"`
-	RecvBytesDetails NodeMetricDetails `json:"recv_bytes_details"`
+	SendBytes        uint64      `json:"send_bytes"`
+	SendBytesDetails RateDetails `json:"send_bytes_details"`
+	RecvBytes        uint64      `json:"recv_bytes"`
+	RecvBytesDetails RateDetails `json:"recv_bytes_details"`
 }
 
 // MetricsGCQueueLength is metrics of gc queuue length
@@ -75,85 +70,85 @@ type NodeInfo struct {
 	IsRunning bool   `json:"running"`
 	OsPid     OsPid  `json:"os_pid"`
 
-	FdUsed                  int               `json:"fd_used"`
-	FdUsedDetails           NodeMetricDetails `json:"fd_used_details"`
-	FdTotal                 int               `json:"fd_total"`
-	ProcUsed                int               `json:"proc_used"`
-	ProcUsedDetails         NodeMetricDetails `json:"proc_used_details"`
-	ProcTotal               int               `json:"proc_total"`
-	SocketsUsed             int               `json:"sockets_used"`
-	SocketsUsedDetails      NodeMetricDetails `json:"sockets_used_details"`
-	SocketsTotal            int               `json:"sockets_total"`
-	MemUsed                 int               `json:"mem_used"`
-	MemUsedDetails          NodeMetricDetails `json:"mem_used_details"`
-	MemLimit                int               `json:"mem_limit"`
-	MemAlarm                bool              `json:"mem_alarm"`
-	DiskFree                int               `json:"disk_free"`
-	DiskFreeDetails         NodeMetricDetails `json:"disk_free_details"`
-	DiskFreeLimit           int               `json:"disk_free_limit"`
-	DiskFreeAlarm           bool              `json:"disk_free_alarm"`
-	GCNum                   uint64            `json:"gc_num"`
-	GCNumDetails            NodeMetricDetails `json:"gc_num_details"`
-	GCBytesReclaimed        uint64            `json:"gc_bytes_reclaimed"`
-	GCBytesReclaimedDetails NodeMetricDetails `json:"gc_bytes_reclaimed_details"`
-	ContextSwitches         uint64            `json:"context_switches"`
-	ContextSwitchesDetails  NodeMetricDetails `json:"context_switches_details"`
+	FdUsed                  int         `json:"fd_used"`
+	FdUsedDetails           RateDetails `json:"fd_used_details"`
+	FdTotal                 int         `json:"fd_total"`
+	ProcUsed                int         `json:"proc_used"`
+	ProcUsedDetails         RateDetails `json:"proc_used_details"`
+	ProcTotal               int         `json:"proc_total"`
+	SocketsUsed             int         `json:"sockets_used"`
+	SocketsUsedDetails      RateDetails `json:"sockets_used_details"`
+	SocketsTotal            int         `json:"sockets_total"`
+	MemUsed                 int         `json:"mem_used"`
+	MemUsedDetails          RateDetails `json:"mem_used_details"`
+	MemLimit                int         `json:"mem_limit"`
+	MemAlarm                bool        `json:"mem_alarm"`
+	DiskFree                int         `json:"disk_free"`
+	DiskFreeDetails         RateDetails `json:"disk_free_details"`
+	DiskFreeLimit           int         `json:"disk_free_limit"`
+	DiskFreeAlarm           bool        `json:"disk_free_alarm"`
+	GCNum                   uint64      `json:"gc_num"`
+	GCNumDetails            RateDetails `json:"gc_num_details"`
+	GCBytesReclaimed        uint64      `json:"gc_bytes_reclaimed"`
+	GCBytesReclaimedDetails RateDetails `json:"gc_bytes_reclaimed_details"`
+	ContextSwitches         uint64      `json:"context_switches"`
+	ContextSwitchesDetails  RateDetails `json:"context_switches_details"`
 
-	ConnectionCreated        uint64            `json:"connection_created"`
-	ConnectionCreatedDetails NodeMetricDetails `json:"connection_created_details"`
-	ConnectionClosed         uint64            `json:"connection_closed"`
-	ConnectionClosedDetails  NodeMetricDetails `json:"connection_closed_details"`
-	ChannelCreated           uint64            `json:"channel_created"`
-	ChannelCreatedDetails    NodeMetricDetails `json:"channel_created_details"`
-	ChannelClosed            uint64            `json:"channel_closed"`
-	ChannelClosedDetails     NodeMetricDetails `json:"channel_closed_details"`
-	QueueDeclared            uint64            `json:"queue_declared"`
-	QueueDeclaredDetails     NodeMetricDetails `json:"queue_declared_details"`
-	QueueCreated             uint64            `json:"queue_created"`
-	QueueCreatedDetails      NodeMetricDetails `json:"queue_created_details"`
-	QueueDeleted             uint64            `json:"queue_deleted"`
-	QueueDeletedDetails      NodeMetricDetails `json:"queue_deleted_details"`
+	ConnectionCreated        uint64      `json:"connection_created"`
+	ConnectionCreatedDetails RateDetails `json:"connection_created_details"`
+	ConnectionClosed         uint64      `json:"connection_closed"`
+	ConnectionClosedDetails  RateDetails `json:"connection_closed_details"`
+	ChannelCreated           uint64      `json:"channel_created"`
+	ChannelCreatedDetails    RateDetails `json:"channel_created_details"`
+	ChannelClosed            uint64      `json:"channel_closed"`
+	ChannelClosedDetails     RateDetails `json:"channel_closed_details"`
+	QueueDeclared            uint64      `json:"queue_declared"`
+	QueueDeclaredDetails     RateDetails `json:"queue_declared_details"`
+	QueueCreated             uint64      `json:"queue_created"`
+	QueueCreatedDetails      RateDetails `json:"queue_created_details"`
+	QueueDeleted             uint64      `json:"queue_deleted"`
+	QueueDeletedDetails      RateDetails `json:"queue_deleted_details"`
 
-	IOReadCount                         uint64            `json:"io_read_count"`
-	IOReadCountDetails                  NodeMetricDetails `json:"io_read_count_details"`
-	IOReadBytes                         uint64            `json:"io_read_bytes"`
-	IOReadBytesDetails                  NodeMetricDetails `json:"io_read_bytes"`
-	IOReadAvgTime                       float64           `json:"io_read_avg_time"`
-	IOReadAvgTimeDetails                NodeMetricDetails `json:"io_read_avg_time_details"`
-	IOWriteCount                        uint64            `json:"io_write_count"`
-	IOWriteCountDetails                 NodeMetricDetails `json:"io_write_count_details"`
-	IOWriteBytes                        uint64            `json:"io_write_bytes"`
-	IOWriteBytesDetails                 NodeMetricDetails `json:"io_write_bytes_details"`
-	IOWriteAvgTime                      float64           `json:"io_write_avg_time"`
-	IOWriteAvgTimeDetails               NodeMetricDetails `json:"io_write_avg_time_details"`
-	IOSyncCount                         uint64            `json:"io_sync_count"`
-	IOSyncCountDetails                  NodeMetricDetails `json:"io_sync_count_details"`
-	IOSyncAvgTime                       float64           `json:"io_sync_avg_time"`
-	IOSyncAvgTimeDetails                NodeMetricDetails `json:"io_sync_avg_time_details"`
-	IOSeekCount                         uint64            `json:"io_seek_count"`
-	IOSeekCountDetails                  NodeMetricDetails `json:"io_seek_count_details"`
-	IOSeekAvgTime                       float64           `json:"io_seek_avg_time"`
-	IOSeekAvgTimeDetails                NodeMetricDetails `json:"io_seek_avg_time_details"`
-	IOReopenCount                       uint64            `json:"io_reopen_count"`
-	IOReopenCountDetails                NodeMetricDetails `json:"io_reopen_count_details"`
-	IOFileHandleOpenAttemptCount        uint64            `json:"io_file_handle_open_attempt_count"`
-	IOFileHandleOpenAttemptCountDetails NodeMetricDetails `json:"io_file_handle_open_attempt_count_details"`
+	IOReadCount                         uint64      `json:"io_read_count"`
+	IOReadCountDetails                  RateDetails `json:"io_read_count_details"`
+	IOReadBytes                         uint64      `json:"io_read_bytes"`
+	IOReadBytesDetails                  RateDetails `json:"io_read_bytes"`
+	IOReadAvgTime                       float64     `json:"io_read_avg_time"`
+	IOReadAvgTimeDetails                RateDetails `json:"io_read_avg_time_details"`
+	IOWriteCount                        uint64      `json:"io_write_count"`
+	IOWriteCountDetails                 RateDetails `json:"io_write_count_details"`
+	IOWriteBytes                        uint64      `json:"io_write_bytes"`
+	IOWriteBytesDetails                 RateDetails `json:"io_write_bytes_details"`
+	IOWriteAvgTime                      float64     `json:"io_write_avg_time"`
+	IOWriteAvgTimeDetails               RateDetails `json:"io_write_avg_time_details"`
+	IOSyncCount                         uint64      `json:"io_sync_count"`
+	IOSyncCountDetails                  RateDetails `json:"io_sync_count_details"`
+	IOSyncAvgTime                       float64     `json:"io_sync_avg_time"`
+	IOSyncAvgTimeDetails                RateDetails `json:"io_sync_avg_time_details"`
+	IOSeekCount                         uint64      `json:"io_seek_count"`
+	IOSeekCountDetails                  RateDetails `json:"io_seek_count_details"`
+	IOSeekAvgTime                       float64     `json:"io_seek_avg_time"`
+	IOSeekAvgTimeDetails                RateDetails `json:"io_seek_avg_time_details"`
+	IOReopenCount                       uint64      `json:"io_reopen_count"`
+	IOReopenCountDetails                RateDetails `json:"io_reopen_count_details"`
+	IOFileHandleOpenAttemptCount        uint64      `json:"io_file_handle_open_attempt_count"`
+	IOFileHandleOpenAttemptCountDetails RateDetails `json:"io_file_handle_open_attempt_count_details"`
 
-	MnesiaRamTxCount uint64 `json:"mnesia_ram_tx_count"`
+	MnesiaRAMTxCount uint64 `json:"mnesia_ram_tx_count"`
 
-	MnesiaRamTxCountDetails            NodeMetricDetails `json:"mnesia_ram_tx_count_details"`
-	MnesiaDiskTxCount                  uint64            `json:"mnesia_disk_tx_count"`
-	MnesiaDiskTxCountDetails           NodeMetricDetails `json:"mnesia_disk_tx_count_details"`
-	MsgStoreReadCount                  uint64            `json:"msg_store_read_count"`
-	MsgStoreReadCountDetails           NodeMetricDetails `json:"msg_store_read_count_details"`
-	MsgStoreWriteCount                 uint64            `json:"msg_store_write_count"`
-	MsgStoreWriteCountDetails          NodeMetricDetails `json:"msg_store_write_count_details"`
-	QueueIndexJournalWriteCount        uint64            `json:"queue_index_journal_write_count"`
-	QueueIndexJournalWriteCountDetails NodeMetricDetails `json:"queue_index_journal_write_count_details"`
-	QueueIndexWriteCount               uint64            `json:"queue_index_write_count"`
-	QueueIndexWriteCountDetails        NodeMetricDetails `json:"queue_index_write_count_details"`
-	QueueIndexReadCount                uint64            `json:"queue_index_read_count"`
-	QueueIndexReadCountDetails         NodeMetricDetails `json:"queue_index_read_count_details"`
+	MnesiaRAMTxCountDetails            RateDetails `json:"mnesia_ram_tx_count_details"`
+	MnesiaDiskTxCount                  uint64      `json:"mnesia_disk_tx_count"`
+	MnesiaDiskTxCountDetails           RateDetails `json:"mnesia_disk_tx_count_details"`
+	MsgStoreReadCount                  uint64      `json:"msg_store_read_count"`
+	MsgStoreReadCountDetails           RateDetails `json:"msg_store_read_count_details"`
+	MsgStoreWriteCount                 uint64      `json:"msg_store_write_count"`
+	MsgStoreWriteCountDetails          RateDetails `json:"msg_store_write_count_details"`
+	QueueIndexJournalWriteCount        uint64      `json:"queue_index_journal_write_count"`
+	QueueIndexJournalWriteCountDetails RateDetails `json:"queue_index_journal_write_count_details"`
+	QueueIndexWriteCount               uint64      `json:"queue_index_write_count"`
+	QueueIndexWriteCountDetails        RateDetails `json:"queue_index_write_count_details"`
+	QueueIndexReadCount                uint64      `json:"queue_index_read_count"`
+	QueueIndexReadCountDetails         RateDetails `json:"queue_index_read_count_details"`
 
 	// Erlang scheduler run queue length
 	RunQueueLength uint32 `json:"run_queue"`

--- a/nodes.go
+++ b/nodes.go
@@ -7,6 +7,11 @@ import (
 // OsPid is an operating system process ID.
 type OsPid string
 
+// NodeMetricDetails .
+type NodeMetricDetails struct {
+	Rate float64 `rate`
+}
+
 // NameDescriptionEnabled represents a named entity with a description.
 type NameDescriptionEnabled struct {
 	Name        string `json:"name"`
@@ -31,6 +36,38 @@ type NameDescriptionVersion struct {
 // ErlangApp is an Erlang application running on a node.
 type ErlangApp NameDescriptionVersion
 
+// ClusterLink is an inter-node communications link entity in clustering
+type ClusterLink struct {
+	Stats     ClusterLinkStats `json:"stats"`
+	Name      string           `json:"name"`
+	PeerAddr  string           `json:"peer_addr"`
+	PeerPort  uint             `json:"peer_addr"`
+	SockAddr  string           `json:"sock_addr"`
+	SockPort  uint             `json:"sock_addr"`
+	SendBytes uint64           `json:"send_bytes"`
+	RecvBytes uint64           `json:"recv_bytes"`
+}
+
+// ClusterLinkStats is a stats field in ClusterLink
+type ClusterLinkStats struct {
+	SendBytes        uint64            `json:"send_bytes"`
+	SendBytesDetails NodeMetricDetails `json:"send_bytes_details"`
+	RecvBytes        uint64            `json:"recv_bytes"`
+	RecvBytesDetails NodeMetricDetails `json:"recv_bytes_details"`
+}
+
+// MetricsGCQueueLength is metrics of gc queuue length
+type MetricsGCQueueLength struct {
+	ConnectionClosed       int `json:"connection_closed"`
+	ChannelClosed          int `json:"channel_closed"`
+	ConsumerDeleted        int `json:"consumer_deleted"`
+	ExchangeDeleted        int `json:"exchange_deleted"`
+	QueueDeleted           int `json:"queue_deleted"`
+	VhostDeleted           int `json:"vhost_deleted"`
+	NodeNodeDeleted        int `json:"node_node_deleted"`
+	ChannelConsumerDeleted int `json:"channel_consumer_deleted"`
+}
+
 // NodeInfo describes a RabbitMQ node and its basic metrics (such as resource usage).
 type NodeInfo struct {
 	Name      string `json:"name"`
@@ -38,18 +75,85 @@ type NodeInfo struct {
 	IsRunning bool   `json:"running"`
 	OsPid     OsPid  `json:"os_pid"`
 
-	FdUsed        int  `json:"fd_used"`
-	FdTotal       int  `json:"fd_total"`
-	ProcUsed      int  `json:"proc_used"`
-	ProcTotal     int  `json:"proc_total"`
-	SocketsUsed   int  `json:"sockets_used"`
-	SocketsTotal  int  `json:"sockets_total"`
-	MemUsed       int  `json:"mem_used"`
-	MemLimit      int  `json:"mem_limit"`
-	MemAlarm      bool `json:"mem_alarm"`
-	DiskFree      int  `json:"disk_free"`
-	DiskFreeLimit int  `json:"disk_free_limit"`
-	DiskFreeAlarm bool `json:"disk_free_alarm"`
+	FdUsed                  int               `json:"fd_used"`
+	FdUsedDetails           NodeMetricDetails `json:"fd_used_details"`
+	FdTotal                 int               `json:"fd_total"`
+	ProcUsed                int               `json:"proc_used"`
+	ProcUsedDetails         NodeMetricDetails `json:"proc_used_details"`
+	ProcTotal               int               `json:"proc_total"`
+	SocketsUsed             int               `json:"sockets_used"`
+	SocketsUsedDetails      NodeMetricDetails `json:"sockets_used_details"`
+	SocketsTotal            int               `json:"sockets_total"`
+	MemUsed                 int               `json:"mem_used"`
+	MemUsedDetails          NodeMetricDetails `json:"mem_used_details"`
+	MemLimit                int               `json:"mem_limit"`
+	MemAlarm                bool              `json:"mem_alarm"`
+	DiskFree                int               `json:"disk_free"`
+	DiskFreeDetails         NodeMetricDetails `json:"disk_free_details"`
+	DiskFreeLimit           int               `json:"disk_free_limit"`
+	DiskFreeAlarm           bool              `json:"disk_free_alarm"`
+	GCNum                   uint64            `json:"gc_num"`
+	GCNumDetails            NodeMetricDetails `json:"gc_num_details"`
+	GCBytesReclaimed        uint64            `json:"gc_bytes_reclaimed"`
+	GCBytesReclaimedDetails NodeMetricDetails `json:"gc_bytes_reclaimed_details"`
+	ContextSwitches         uint64            `json:"context_switches"`
+	ContextSwitchesDetails  NodeMetricDetails `json:"context_switches_details"`
+
+	ConnectionCreated        uint64            `json:"connection_created"`
+	ConnectionCreatedDetails NodeMetricDetails `json:"connection_created_details"`
+	ConnectionClosed         uint64            `json:"connection_closed"`
+	ConnectionClosedDetails  NodeMetricDetails `json:"connection_closed_details"`
+	ChannelCreated           uint64            `json:"channel_created"`
+	ChannelCreatedDetails    NodeMetricDetails `json:"channel_created_details"`
+	ChannelClosed            uint64            `json:"channel_closed"`
+	ChannelClosedDetails     NodeMetricDetails `json:"channel_closed_details"`
+	QueueDeclared            uint64            `json:"queue_declared"`
+	QueueDeclaredDetails     NodeMetricDetails `json:"queue_declared_details"`
+	QueueCreated             uint64            `json:"queue_created"`
+	QueueCreatedDetails      NodeMetricDetails `json:"queue_created_details"`
+	QueueDeleted             uint64            `json:"queue_deleted"`
+	QueueDeletedDetails      NodeMetricDetails `json:"queue_deleted_details"`
+
+	IOReadCount                         uint64            `json:"io_read_count"`
+	IOReadCountDetails                  NodeMetricDetails `json:"io_read_count_details"`
+	IOReadBytes                         uint64            `json:"io_read_bytes"`
+	IOReadBytesDetails                  NodeMetricDetails `json:"io_read_bytes"`
+	IOReadAvgTime                       float64           `json:"io_read_avg_time"`
+	IOReadAvgTimeDetails                NodeMetricDetails `json:"io_read_avg_time_details"`
+	IOWriteCount                        uint64            `json:"io_write_count"`
+	IOWriteCountDetails                 NodeMetricDetails `json:"io_write_count_details"`
+	IOWriteBytes                        uint64            `json:"io_write_bytes"`
+	IOWriteBytesDetails                 NodeMetricDetails `json:"io_write_bytes_details"`
+	IOWriteAvgTime                      float64           `json:"io_write_avg_time"`
+	IOWriteAvgTimeDetails               NodeMetricDetails `json:"io_write_avg_time_details"`
+	IOSyncCount                         uint64            `json:"io_sync_count"`
+	IOSyncCountDetails                  NodeMetricDetails `json:"io_sync_count_details"`
+	IOSyncAvgTime                       float64           `json:"io_sync_avg_time"`
+	IOSyncAvgTimeDetails                NodeMetricDetails `json:"io_sync_avg_time_details"`
+	IOSeekCount                         uint64            `json:"io_seek_count"`
+	IOSeekCountDetails                  NodeMetricDetails `json:"io_seek_count_details"`
+	IOSeekAvgTime                       float64           `json:"io_seek_avg_time"`
+	IOSeekAvgTimeDetails                NodeMetricDetails `json:"io_seek_avg_time_details"`
+	IOReopenCount                       uint64            `json:"io_reopen_count"`
+	IOReopenCountDetails                NodeMetricDetails `json:"io_reopen_count_details"`
+	IOFileHandleOpenAttemptCount        uint64            `json:"io_file_handle_open_attempt_count"`
+	IOFileHandleOpenAttemptCountDetails NodeMetricDetails `json:"io_file_handle_open_attempt_count_details"`
+
+	MnesiaRamTxCount uint64 `json:"mnesia_ram_tx_count"`
+
+	MnesiaRamTxCountDetails            NodeMetricDetails `json:"mnesia_ram_tx_count_details"`
+	MnesiaDiskTxCount                  uint64            `json:"mnesia_disk_tx_count"`
+	MnesiaDiskTxCountDetails           NodeMetricDetails `json:"mnesia_disk_tx_count_details"`
+	MsgStoreReadCount                  uint64            `json:"msg_store_read_count"`
+	MsgStoreReadCountDetails           NodeMetricDetails `json:"msg_store_read_count_details"`
+	MsgStoreWriteCount                 uint64            `json:"msg_store_write_count"`
+	MsgStoreWriteCountDetails          NodeMetricDetails `json:"msg_store_write_count_details"`
+	QueueIndexJournalWriteCount        uint64            `json:"queue_index_journal_write_count"`
+	QueueIndexJournalWriteCountDetails NodeMetricDetails `json:"queue_index_journal_write_count_details"`
+	QueueIndexWriteCount               uint64            `json:"queue_index_write_count"`
+	QueueIndexWriteCountDetails        NodeMetricDetails `json:"queue_index_write_count_details"`
+	QueueIndexReadCount                uint64            `json:"queue_index_read_count"`
+	QueueIndexReadCountDetails         NodeMetricDetails `json:"queue_index_read_count_details"`
 
 	// Erlang scheduler run queue length
 	RunQueueLength uint32 `json:"run_queue"`
@@ -62,6 +166,10 @@ type NodeInfo struct {
 	Contexts       []BrokerContext `json:"contexts"`
 
 	Partitions []string `json:"partitions"`
+
+	ClusterLinks []ClusterLink `json:"cluster_links"`
+
+	MetricsGCQueueLength MetricsGCQueueLength `json:"metrics_gc_queue_length"`
 }
 
 //

--- a/queues.go
+++ b/queues.go
@@ -44,16 +44,59 @@ type OwnerPidDetails struct {
 	PeerHost string `json:"peer_host"`
 }
 
+// ConsumerDetail describe consumer information with a queue
+type ConsumerDetail struct {
+	Arguments      map[string]interface{} `json:"arguments"`
+	ChannelDetails ChannelDetails         `json:"channel_details"`
+	AckRequired    bool                   `json:"ack_required"`
+	Active         bool                   `json:"active"`
+	ActiveStatus   string                 `json:"active_status"`
+	ConsumerTag    string                 `json:"consumer_tag"`
+	Exclusive      bool                   `json:"exclusive"`
+	PrefetchCount  uint                   `json:"prefetch_count"`
+	Queue          QueueDetail            `json:"queue"`
+}
+
+// ChannelDetails describe channel information with a consumer
+type ChannelDetails struct {
+	ConnectionName string `json:"connection_name"`
+	Name           string `json:"name"`
+	Node           string `json:"node"`
+	Number         uint   `json:"number"`
+	PeerHost       string `json:"peer_host"`
+	PeerPort       uint   `json:"peer_port"`
+	User           string `json:"user"`
+}
+
+// QueueDetail describe queue information with a consumer
+type QueueDetail struct {
+	Name  string `json:"name"`
+	Vhost string `json:"vhost"`
+}
+
+// GarbageCollectionDetail describe queue garbage collection information
+type GarbageCollectionDetail struct {
+	FullSweepAfter  uint `json:"fullsweep_after"`
+	MaxHeapSize     uint `json:"max_heap_size"`
+	MinBinVheapSize uint `json:"min_bin_vheap_size"`
+	MinHeapSize     uint `json:"min_heap_size"`
+	MinorGCs        uint `json:"minor_gcs"`
+}
+
 // QueueInfo represents a queue, its properties and key metrics.
 type QueueInfo struct {
 	// Queue name
 	Name string `json:"name"`
+	// Queue type
+	Type string `json:"type"`
 	// Virtual host this queue belongs to
 	Vhost string `json:"vhost"`
 	// Is this queue durable?
 	Durable bool `json:"durable"`
 	// Is this queue auto-deleted?
 	AutoDelete bool `json:"auto_delete"`
+	// Is this queue exclusive?
+	Exclusive bool `json:"exclusive"`
 	// Extra queue arguments
 	Arguments map[string]interface{} `json:"arguments"`
 
@@ -61,23 +104,35 @@ type QueueInfo struct {
 	Node string `json:"node"`
 	// Queue status
 	Status string `json:"state"`
+	// Queue leader when it is quorum queue
+	Leader string `json:"leader"`
+	// Queue members when it is quorum queue
+	Members []string `json:"members"`
+	// Queue online members when it is quorum queue
+	Online []string `json:"online"`
 
 	// Total amount of RAM used by this queue
 	Memory int64 `json:"memory"`
 	// How many consumers this queue has
 	Consumers int `json:"consumers"`
+	// Detail information of consumers
+	ConsumerDetails []ConsumerDetail `json:"consumer_details"`
 	// Utilisation of all the consumers
 	ConsumerUtilisation float64 `json:"consumer_utilisation"`
 	// If there is an exclusive consumer, its consumer tag
 	ExclusiveConsumerTag string `json:"exclusive_consumer_tag"`
 
+	GarbageCollection GarbageCollectionDetail `json:"garbage_collection"`
+
 	// Policy applied to this queue, if any
 	Policy string `json:"policy"`
 
 	// Total bytes of messages in this queues
-	MessagesBytes           int64 `json:"message_bytes"`
-	MessagesBytesPersistent int64 `json:"message_bytes_persistent"`
-	MessagesBytesRAM        int64 `json:"message_bytes_ram"`
+	MessagesBytes               int64 `json:"message_bytes"`
+	MessagesBytesPersistent     int64 `json:"message_bytes_persistent"`
+	MessagesBytesRAM            int64 `json:"message_bytes_ram"`
+	MessagesBytesReady          int64 `json:"message_bytes_ready"`
+	MessagesBytesUnacknowledged int64 `json:"message_bytes_unacknowledged"`
 
 	// Total number of messages in this queue
 	Messages           int         `json:"messages"`
@@ -300,7 +355,7 @@ func (c *Client) DeclareQueue(vhost, queue string, info QueueSettings) (res *htt
 	if info.Arguments == nil {
 		info.Arguments = make(map[string]interface{})
 	}
-	
+
 	if info.Type != "" {
 		info.Arguments["x-queue-type"] = info.Type
 	}

--- a/queues.go
+++ b/queues.go
@@ -75,12 +75,12 @@ type QueueDetail struct {
 }
 
 // GarbageCollectionDetail describe queue garbage collection information
-type GarbageCollectionDetail struct {
-	FullSweepAfter  uint `json:"fullsweep_after"`
-	MaxHeapSize     uint `json:"max_heap_size"`
-	MinBinVheapSize uint `json:"min_bin_vheap_size"`
-	MinHeapSize     uint `json:"min_heap_size"`
-	MinorGCs        uint `json:"minor_gcs"`
+type GarbageCollectionDetails struct {
+	FullSweepAfter  int `json:"fullsweep_after"`
+	MaxHeapSize     int `json:"max_heap_size"`
+	MinBinVheapSize int `json:"min_bin_vheap_size"`
+	MinHeapSize     int `json:"min_heap_size"`
+	MinorGCs        int `json:"minor_gcs"`
 }
 
 // QueueInfo represents a queue, its properties and key metrics.
@@ -122,7 +122,8 @@ type QueueInfo struct {
 	// If there is an exclusive consumer, its consumer tag
 	ExclusiveConsumerTag string `json:"exclusive_consumer_tag"`
 
-	GarbageCollection GarbageCollectionDetail `json:"garbage_collection"`
+	// GarbageCollection metrics
+	GarbageCollection GarbageCollectionDetails `json:"garbage_collection"`
 
 	// Policy applied to this queue, if any
 	Policy string `json:"policy"`


### PR DESCRIPTION
I am in a SRE team. We are running rabbitmq 3.8.5 in production and find it may be useful to add more fields of metrics for NodeInfo and QueueInfo, because we could know more about running state for rabbitmq instance