### PR TITLE
Add vhost-limits API

### DIFF
--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -989,6 +989,35 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 		})
 	})
 
+	Context("vhost-limits", func() {
+		maxConnections := 1
+		It("returns an empty list of limits", func() {
+			xs, err := rmqc.GetVhostLimits("rabbit/hole")
+			Ω(err).Should(BeNil())
+			Ω(xs).Should(HaveLen(0))
+		})
+		It("sets the max-connections limit", func() {
+			_, err := rmqc.PutVhostLimitsMaxConnections("rabbit/hole", maxConnections)
+			Ω(err).Should(BeNil())
+		})
+		It("returns the max-connections limit", func() {
+			xs, err := rmqc.GetVhostLimits("rabbit/hole")
+			Ω(err).Should(BeNil())
+			Ω(xs).Should(HaveLen(1))
+			Ω(xs[0].Vhost).Should(Equal("rabbit/hole"))
+			Ω(xs[0].Value.MaxConnections).Should(Equal(maxConnections))
+		})
+		It("deletes the max-connections limit", func() {
+			_, err := rmqc.DeleteVhostLimitsMaxConnections("rabbit/hole")
+			Ω(err).Should(BeNil())
+		})
+		It("returns the max-connections limit", func() {
+			xs, err := rmqc.GetVhostLimits("rabbit/hole")
+			Ω(err).Should(BeNil())
+			Ω(xs).Should(HaveLen(0))
+		})
+	})
+
 	Context("GET /bindings", func() {
 		It("returns decoded response", func() {
 			conn := openConnection("/")

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -991,27 +991,32 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 
 	Context("vhost-limits", func() {
 		maxConnections := 1
+		maxQueues := 2
 		It("returns an empty list of limits", func() {
 			xs, err := rmqc.GetVhostLimits("rabbit/hole")
 			Ω(err).Should(BeNil())
 			Ω(xs).Should(HaveLen(0))
 		})
-		It("sets the max-connections limit", func() {
-			_, err := rmqc.PutVhostLimitsMaxConnections("rabbit/hole", maxConnections)
+		It("sets the limits", func() {
+			_, err := rmqc.PutVhostLimits("rabbit/hole", VhostLimitsValues{
+				"max-connections":maxConnections,
+				"max-queues":maxQueues,
+			})
 			Ω(err).Should(BeNil())
 		})
-		It("returns the max-connections limit", func() {
+		It("returns the limits", func() {
 			xs, err := rmqc.GetVhostLimits("rabbit/hole")
 			Ω(err).Should(BeNil())
 			Ω(xs).Should(HaveLen(1))
 			Ω(xs[0].Vhost).Should(Equal("rabbit/hole"))
-			Ω(xs[0].Value.MaxConnections).Should(Equal(maxConnections))
+			Ω(xs[0].Value["max-connections"]).Should(Equal(maxConnections))
+			Ω(xs[0].Value["max-queues"]).Should(Equal(maxQueues))
 		})
-		It("deletes the max-connections limit", func() {
-			_, err := rmqc.DeleteVhostLimitsMaxConnections("rabbit/hole")
+		It("deletes the limits", func() {
+			_, err := rmqc.DeleteVhostLimits("rabbit/hole", VhostLimits{"max-connections", "max-queues"})
 			Ω(err).Should(BeNil())
 		})
-		It("returns the max-connections limit", func() {
+		It("returns an empty list of limits", func() {
 			xs, err := rmqc.GetVhostLimits("rabbit/hole")
 			Ω(err).Should(BeNil())
 			Ω(xs).Should(HaveLen(0))

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -999,8 +999,8 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 		})
 		It("sets the limits", func() {
 			_, err := rmqc.PutVhostLimits("rabbit/hole", VhostLimitsValues{
-				"max-connections":maxConnections,
-				"max-queues":maxQueues,
+				"max-connections": maxConnections,
+				"max-queues":      maxQueues,
 			})
 			Ω(err).Should(BeNil())
 		})

--- a/vhost_limits.go
+++ b/vhost_limits.go
@@ -1,0 +1,66 @@
+package rabbithole
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+)
+
+// VhostLimitsValue are properties used to modify virtual hosts limits.
+type VhostLimitsValue struct {
+	// Maximum number of connections
+	MaxConnections int `json:"max-connections"`
+}
+
+type VhostLimitsInfo struct {
+	Vhost string           `json:"vhost"`
+	Value VhostLimitsValue `json:"value"`
+}
+
+type VhostLimitsMaxConnections struct {
+	Value int `json:"value"`
+}
+
+func (c *Client) GetVhostLimits(vhostname string) (rec []VhostLimitsInfo, err error) {
+	req, err := newGETRequest(c, "vhost-limits/"+url.PathEscape(vhostname))
+	if err != nil {
+		return nil, err
+	}
+
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
+		return nil, err
+	}
+
+	return rec, nil
+}
+
+func (c *Client) PutVhostLimitsMaxConnections(vhostname string, maxConnections int) (res *http.Response, err error) {
+	body, err := json.Marshal(VhostLimitsMaxConnections{Value: maxConnections})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := newRequestWithBody(c, "PUT", "vhost-limits/"+url.PathEscape(vhostname)+"/max-connections", body)
+	if err != nil {
+		return nil, err
+	}
+
+	if res, err = executeRequest(c, req); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (c *Client) DeleteVhostLimitsMaxConnections(vhostname string) (res *http.Response, err error) {
+	req, err := newRequestWithBody(c, "DELETE", "vhost-limits/"+url.PathEscape(vhostname)+"/max-connections", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if res, err = executeRequest(c, req); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
This pull request adds support to set the max-connection limit for a specified vhost (see REST API: /api/vhost-limits)