### PR TITLE
Avoid exporting stats and empty fields

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -46,14 +46,14 @@ func (v BindingVertex) String() string {
 type BindingInfo struct {
 	// Binding source (exchange name)
 	Source string `json:"source"`
-	Vhost  string `json:"vhost"`
+	Vhost  string `json:"vhost,omitempty"`
 	// Binding destination (queue or exchange name)
 	Destination string `json:"destination"`
 	// Destination type, either "queue" or "exchange"
 	DestinationType string                 `json:"destination_type"`
 	RoutingKey      string                 `json:"routing_key"`
 	Arguments       map[string]interface{} `json:"arguments"`
-	PropertiesKey   string                 `json:"properties_key"`
+	PropertiesKey   string                 `json:"properties_key,omitempty"`
 }
 
 // ListBindings returns all bindings

--- a/definitions.go
+++ b/definitions.go
@@ -2,20 +2,20 @@ package rabbithole
 
 // ExportedDefinitions represents definitions exported from a RabbitMQ cluster
 type ExportedDefinitions struct {
-	RabbitVersion    string `json:"rabbit_version"`
-	RabbitMQVersion  string `json:"rabbitmq_version"`
-	ProductName      string `json:"product_name"`
-	ProductVersion   string `json:"product_version"`
-	Users            []UserInfo
-	Vhosts           []VhostInfo
-	Permissions      []Permissions
-	TopicPermissions []TopicPermissionInfo
-	Parameters       []RuntimeParameter
-	GlobalParameters []GlobalRuntimeParameter `json:"global_parameters"`
-	Policies         []PolicyDefinition
-	Queues           []QueueInfo
-	Exchanges        []ExchangeInfo
-	Bindings         []BindingInfo
+	RabbitVersion    string                    `json:"rabbit_version,omitempty"`
+	RabbitMQVersion  string                    `json:"rabbitmq_version,omitempty"`
+	ProductName      string                    `json:"product_name,omitempty"`
+	ProductVersion   string                    `json:"product_version,omitempty"`
+	Users            *[]UserInfo               `json:"users,omitempty"`
+	Vhosts           *[]VhostInfo              `json:"vhosts,omitempty"`
+	Permissions      *[]Permissions            `json:"permissions,omitempty"`
+	TopicPermissions *[]TopicPermissionInfo    `json:"topic_permissions,omitempty"`
+	Parameters       *[]RuntimeParameter       `json:"paramaters,omitempty"`
+	GlobalParameters *[]GlobalRuntimeParameter `json:"global_parameters,omitempty"`
+	Policies         *[]PolicyDefinition       `json:"policies"`
+	Queues           *[]QueueInfo              `json:"queues"`
+	Exchanges        *[]ExchangeInfo           `json:"exchanges"`
+	Bindings         *[]BindingInfo            `json:"bindings"`
 }
 
 //

--- a/exchanges.go
+++ b/exchanges.go
@@ -12,24 +12,24 @@ import (
 
 // IngressEgressStats represents common message flow metrics.
 type IngressEgressStats struct {
-	PublishIn        int         `json:"publish_in"`
-	PublishInDetails RateDetails `json:"publish_in_details"`
+	PublishIn        int          `json:"publish_in,omitempty"`
+	PublishInDetails *RateDetails `json:"publish_in_details,omitempty"`
 
-	PublishOut        int         `json:"publish_out"`
-	PublishOutDetails RateDetails `json:"publish_out_details"`
+	PublishOut        int          `json:"publish_out,omitempty"`
+	PublishOutDetails *RateDetails `json:"publish_out_details,omitempty"`
 }
 
 // ExchangeInfo represents and exchange and its properties.
 type ExchangeInfo struct {
 	Name       string                 `json:"name"`
-	Vhost      string                 `json:"vhost"`
+	Vhost      string                 `json:"vhost,omitempty"`
 	Type       string                 `json:"type"`
 	Durable    bool                   `json:"durable"`
 	AutoDelete bool                   `json:"auto_delete"`
 	Internal   bool                   `json:"internal"`
 	Arguments  map[string]interface{} `json:"arguments"`
 
-	MessageStats IngressEgressStats `json:"message_stats"`
+	MessageStats *IngressEgressStats `json:"message_stats,omitempty"`
 }
 
 // ExchangeSettings is a set of exchange properties. Use this type when declaring

--- a/queues.go
+++ b/queues.go
@@ -9,39 +9,39 @@ import (
 // BackingQueueStatus exposes backing queue (queue storage engine) metrics.
 // They can change in a future version of RabbitMQ.
 type BackingQueueStatus struct {
-	Q1 int `json:"q1"`
-	Q2 int `json:"q2"`
-	Q3 int `json:"q3"`
-	Q4 int `json:"q4"`
+	Q1 int `json:"q1,omitempty"`
+	Q2 int `json:"q2,omitempty"`
+	Q3 int `json:"q3,omitempty"`
+	Q4 int `json:"q4,omitempty"`
 	// Total queue length
-	Length int64 `json:"len"`
+	Length int64 `json:"len,omitempty"`
 	// Number of pending acks from consumers
-	PendingAcks int64 `json:"pending_acks"`
+	PendingAcks int64 `json:"pending_acks,omitempty"`
 	// Number of messages held in RAM
-	RAMMessageCount int64 `json:"ram_msg_count"`
+	RAMMessageCount int64 `json:"ram_msg_count,omitempty"`
 	// Number of outstanding acks held in RAM
-	RAMAckCount int64 `json:"ram_ack_count"`
+	RAMAckCount int64 `json:"ram_ack_count,omitempty"`
 	// Number of persistent messages in the store
-	PersistentCount int64 `json:"persistent_count"`
+	PersistentCount int64 `json:"persistent_count,omitempty"`
 	// Average ingress (inbound) rate, not including messages
 	// that straight through to auto-acking consumers.
-	AverageIngressRate float64 `json:"avg_ingress_rate"`
+	AverageIngressRate float64 `json:"avg_ingress_rate,omitempty"`
 	// Average egress (outbound) rate, not including messages
 	// that straight through to auto-acking consumers.
-	AverageEgressRate float64 `json:"avg_egress_rate"`
+	AverageEgressRate float64 `json:"avg_egress_rate,omitempty"`
 	// rate at which unacknowledged message records enter RAM,
 	// e.g. because messages are delivered requiring acknowledgement
-	AverageAckIngressRate float32 `json:"avg_ack_ingress_rate"`
+	AverageAckIngressRate float32 `json:"avg_ack_ingress_rate,omitempty"`
 	// rate at which unacknowledged message records leave RAM,
 	// e.g. because acks arrive or unacked messages are paged out
-	AverageAckEgressRate float32 `json:"avg_ack_egress_rate"`
+	AverageAckEgressRate float32 `json:"avg_ack_egress_rate,omitempty"`
 }
 
 // OwnerPidDetails describes an exclusive queue owner (connection).
 type OwnerPidDetails struct {
-	Name     string `json:"name"`
-	PeerPort Port   `json:"peer_port"`
-	PeerHost string `json:"peer_host"`
+	Name     string `json:"name,omitempty"`
+	PeerPort Port   `json:"peer_port,omitempty"`
+	PeerHost string `json:"peer_host,omitempty"`
 }
 
 // ConsumerDetail describe consumer information with a queue
@@ -71,7 +71,7 @@ type ChannelDetails struct {
 // QueueDetail describe queue information with a consumer
 type QueueDetail struct {
 	Name  string `json:"name"`
-	Vhost string `json:"vhost"`
+	Vhost string `json:"vhost,omitempty"`
 }
 
 // GarbageCollectionDetail describe queue garbage collection information
@@ -90,7 +90,7 @@ type QueueInfo struct {
 	// Queue type
 	Type string `json:"type"`
 	// Virtual host this queue belongs to
-	Vhost string `json:"vhost"`
+	Vhost string `json:"vhost,omitempty"`
 	// Is this queue durable?
 	Durable bool `json:"durable"`
 	// Is this queue auto-deleted?
@@ -101,9 +101,9 @@ type QueueInfo struct {
 	Arguments map[string]interface{} `json:"arguments"`
 
 	// RabbitMQ node that hosts master for this queue
-	Node string `json:"node"`
+	Node string `json:"node,omitempty"`
 	// Queue status
-	Status string `json:"state"`
+	Status string `json:"state,omitempty"`
 	// Queue leader when it is quorum queue
 	Leader string `json:"leader"`
 	// Queue members when it is quorum queue
@@ -112,9 +112,9 @@ type QueueInfo struct {
 	Online []string `json:"online"`
 
 	// Total amount of RAM used by this queue
-	Memory int64 `json:"memory"`
+	Memory int64 `json:"memory,omitempty"`
 	// How many consumers this queue has
-	Consumers int `json:"consumers"`
+	Consumers int `json:"consumers,omitempty"`
 	// Detail information of consumers
 	ConsumerDetails []ConsumerDetail `json:"consumer_details"`
 	// Utilisation of all the consumers
@@ -126,36 +126,36 @@ type QueueInfo struct {
 	GarbageCollection GarbageCollectionDetails `json:"garbage_collection"`
 
 	// Policy applied to this queue, if any
-	Policy string `json:"policy"`
+	Policy string `json:"policy,omitempty"`
 
 	// Total bytes of messages in this queues
-	MessagesBytes               int64 `json:"message_bytes"`
-	MessagesBytesPersistent     int64 `json:"message_bytes_persistent"`
-	MessagesBytesRAM            int64 `json:"message_bytes_ram"`
-	MessagesBytesReady          int64 `json:"message_bytes_ready"`
-	MessagesBytesUnacknowledged int64 `json:"message_bytes_unacknowledged"`
+	MessagesBytes               int64 `json:"message_bytes,omitempty"`
+	MessagesBytesPersistent     int64 `json:"message_bytes_persistent,omitempty"`
+	MessagesBytesRAM            int64 `json:"message_bytes_ram,omitempty"`
+	MessagesBytesReady          int64 `json:"message_bytes_ready,omitempty"`
+	MessagesBytesUnacknowledged int64 `json:"message_bytes_unacknowledged,omitempty"`
 
 	// Total number of messages in this queue
-	Messages           int         `json:"messages"`
-	MessagesDetails    RateDetails `json:"messages_details"`
-	MessagesPersistent int         `json:"messages_persistent"`
-	MessagesRAM        int         `json:"messages_ram"`
+	Messages           int         `json:"messages,omitempty"`
+	MessagesDetails    RateDetails `json:"messages_details,omitempty"`
+	MessagesPersistent int         `json:"messages_persistent,omitempty"`
+	MessagesRAM        int         `json:"messages_ram,omitempty"`
 
 	// Number of messages ready to be delivered
-	MessagesReady        int         `json:"messages_ready"`
-	MessagesReadyDetails RateDetails `json:"messages_ready_details"`
+	MessagesReady        int         `json:"messages_ready,omitempty"`
+	MessagesReadyDetails RateDetails `json:"messages_ready_details,omitempty"`
 
 	// Number of messages delivered and pending acknowledgements from consumers
-	MessagesUnacknowledged        int         `json:"messages_unacknowledged"`
-	MessagesUnacknowledgedDetails RateDetails `json:"messages_unacknowledged_details"`
+	MessagesUnacknowledged        int         `json:"messages_unacknowledged,omitempty"`
+	MessagesUnacknowledgedDetails RateDetails `json:"messages_unacknowledged_details,omitempty"`
 
-	MessageStats MessageStats `json:"message_stats"`
+	MessageStats MessageStats `json:"message_stats,omitempty"`
 
-	OwnerPidDetails OwnerPidDetails `json:"owner_pid_details"`
+	OwnerPidDetails OwnerPidDetails `json:"owner_pid_details,omitempty"`
 
-	BackingQueueStatus BackingQueueStatus `json:"backing_queue_status"`
+	BackingQueueStatus BackingQueueStatus `json:"backing_queue_status,omitempty"`
 
-	ActiveConsumers int64 `json:"active_consumers"`
+	ActiveConsumers int64 `json:"active_consumers,omitempty"`
 }
 
 // PagedQueueInfo is additional context returned for paginated requests.

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -3000,12 +3000,12 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 
 			Ω(defs.RabbitMQVersion).ShouldNot(BeNil())
 
-			Ω(defs.Vhosts).ShouldNot(BeEmpty())
-			Ω(defs.Users).ShouldNot(BeEmpty())
+			Ω(*defs.Vhosts).ShouldNot(BeEmpty())
+			Ω(*defs.Users).ShouldNot(BeEmpty())
 
-			Ω(defs.Queues).ShouldNot(BeNil())
-			Ω(defs.Parameters).ShouldNot(BeNil())
-			Ω(defs.Policies).ShouldNot(BeNil())
+			Ω(*defs.Queues).ShouldNot(BeNil())
+			Ω(defs.Parameters).Should(BeNil())
+			Ω(*defs.Policies).ShouldNot(BeNil())
 		})
 
 		It("returns exported global parameters", func() {
@@ -3015,7 +3015,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 			Ω(defs).ShouldNot(BeNil())
 
 			foundClusterName := false
-			for _, param := range defs.GlobalParameters {
+			for _, param := range *defs.GlobalParameters {
 				if param.Name == "cluster_name" {
 					foundClusterName = true
 				}


### PR DESCRIPTION
Exported definitions should not include stats and many empty fields.