### PR TITLE
Add support for user limits

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,8 @@
 ## Changes Between 2.11.0 and 2.12.0 (unreleased)
 
-No changes yet.
+Added support to manage user limits.
 
+Added an operation to query all vhost limits at once.
 
 ## Changes Between 2.10.0 and 2.11.0 (Sep 16, 2021)
 

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -1116,6 +1116,14 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 			})
 			Ω(err).Should(BeNil())
 		})
+		It("returns all the limits", func() {
+			xs, err := rmqc.GetAllVhostLimits()
+			Ω(err).Should(BeNil())
+			Ω(xs).Should(HaveLen(1))
+			Ω(xs[0].Vhost).Should(Equal("rabbit/hole"))
+			Ω(xs[0].Value["max-connections"]).Should(Equal(maxConnections))
+			Ω(xs[0].Value["max-queues"]).Should(Equal(maxQueues))
+		})
 		It("returns the limits", func() {
 			xs, err := rmqc.GetVhostLimits("rabbit/hole")
 			Ω(err).Should(BeNil())
@@ -1130,6 +1138,48 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 		})
 		It("returns an empty list of limits", func() {
 			xs, err := rmqc.GetVhostLimits("rabbit/hole")
+			Ω(err).Should(BeNil())
+			Ω(xs).Should(HaveLen(0))
+		})
+	})
+
+	Context("user-limits", func() {
+		maxConnections := 1
+		maxChannels := 2
+		It("returns an empty list of limits", func() {
+			xs, err := rmqc.GetUserLimits("guest")
+			Ω(err).Should(BeNil())
+			Ω(xs).Should(HaveLen(0))
+		})
+		It("sets the limits", func() {
+			_, err := rmqc.PutUserLimits("guest", UserLimitsValues{
+				"max-connections": maxConnections,
+				"max-channels":    maxChannels,
+			})
+			Ω(err).Should(BeNil())
+		})
+		It("returns the limits", func() {
+			xs, err := rmqc.GetUserLimits("guest")
+			Ω(err).Should(BeNil())
+			Ω(xs).Should(HaveLen(1))
+			Ω(xs[0].User).Should(Equal("guest"))
+			Ω(xs[0].Value["max-connections"]).Should(Equal(maxConnections))
+			Ω(xs[0].Value["max-channels"]).Should(Equal(maxChannels))
+		})
+		It("returns all the limits", func() {
+			xs, err := rmqc.GetAllUserLimits()
+			Ω(err).Should(BeNil())
+			Ω(xs).Should(HaveLen(1))
+			Ω(xs[0].User).Should(Equal("guest"))
+			Ω(xs[0].Value["max-connections"]).Should(Equal(maxConnections))
+			Ω(xs[0].Value["max-channels"]).Should(Equal(maxChannels))
+		})
+		It("deletes the limits", func() {
+			_, err := rmqc.DeleteUserLimits("guest", UserLimits{"max-connections", "max-channels"})
+			Ω(err).Should(BeNil())
+		})
+		It("returns an empty list of limits", func() {
+			xs, err := rmqc.GetUserLimits("guest")
 			Ω(err).Should(BeNil())
 			Ω(xs).Should(HaveLen(0))
 		})

--- a/user_limits.go
+++ b/user_limits.go
@@ -1,0 +1,86 @@
+package rabbithole
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+)
+
+// UserLimitsValues are properties used to modify virtual host limits (max-connections, max-channels)
+type UserLimitsValues map[string]int
+
+// UserLimits are properties used to delete virtual host limits (max-connections, max-channels)
+type UserLimits []string
+
+// UserLimitsInfo holds information about the current user limits
+type UserLimitsInfo struct {
+	User  string           `json:"user"`
+	Value UserLimitsValues `json:"value"`
+}
+
+// GetAllUserLimits gets all users limits.
+func (c *Client) GetAllUserLimits() (rec []UserLimitsInfo, err error) {
+	req, err := newGETRequest(c, "user-limits")
+	if err != nil {
+		return nil, err
+	}
+
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
+		return nil, err
+	}
+
+	return rec, nil
+}
+
+// GetUserLimits gets a user limits.
+func (c *Client) GetUserLimits(username string) (rec []UserLimitsInfo, err error) {
+	req, err := newGETRequest(c, "user-limits/"+url.PathEscape(username))
+	if err != nil {
+		return nil, err
+	}
+
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
+		return nil, err
+	}
+
+	return rec, nil
+}
+
+// PutUserLimits puts limits of a user.
+func (c *Client) PutUserLimits(username string, limits UserLimitsValues) (res *http.Response, err error) {
+	for limitName, limitValue := range limits {
+		body, err := json.Marshal(struct {
+			Value int `json:"value"`
+		}{Value: limitValue})
+		if err != nil {
+			return nil, err
+		}
+
+		req, err := newRequestWithBody(c, "PUT", "user-limits/"+url.PathEscape(username)+"/"+limitName, body)
+		if err != nil {
+			return nil, err
+		}
+
+		if res, err = executeRequest(c, req); err != nil {
+			return nil, err
+		}
+	}
+
+	return res, nil
+}
+
+// DeleteUserLimits deletes limits of a user.
+func (c *Client) DeleteUserLimits(username string, limits UserLimits) (res *http.Response, err error) {
+	for _, limit := range limits {
+		req, err := newRequestWithBody(c, "DELETE", "user-limits/"+url.PathEscape(username)+"/"+limit, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		if res, err = executeRequest(c, req); err != nil {
+			return nil, err
+		}
+	}
+
+	return res, nil
+}

--- a/vhost_limits.go
+++ b/vhost_limits.go
@@ -18,6 +18,20 @@ type VhostLimitsInfo struct {
 	Value VhostLimitsValues `json:"value"`
 }
 
+// GetAllVhostLimits gets all virtual hosts limits.
+func (c *Client) GetAllVhostLimits() (rec []VhostLimitsInfo, err error) {
+	req, err := newGETRequest(c, "vhost-limits")
+	if err != nil {
+		return nil, err
+	}
+
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
+		return nil, err
+	}
+
+	return rec, nil
+}
+
 // GetVhostLimits gets a virtual host limits.
 func (c *Client) GetVhostLimits(vhostname string) (rec []VhostLimitsInfo, err error) {
 	req, err := newGETRequest(c, "vhost-limits/"+url.PathEscape(vhostname))
@@ -35,7 +49,9 @@ func (c *Client) GetVhostLimits(vhostname string) (rec []VhostLimitsInfo, err er
 // PutVhostLimits puts limits of a virtual host.
 func (c *Client) PutVhostLimits(vhostname string, limits VhostLimitsValues) (res *http.Response, err error) {
 	for limitName, limitValue := range limits {
-		body, err := json.Marshal(struct{Value int `json:"value"`}{Value: limitValue})
+		body, err := json.Marshal(struct {
+			Value int `json:"value"`
+		}{Value: limitValue})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR addresses #216 and adds support for user limits feature which was added in RMQ 3.8.10.

It also adds functions to query vhost and user limits for all vhosts and users respectively. 