### PR TITLE
Switch to Gomega's Eventually matcher

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ To enable the plugins:
 ./bin/ci/before_build.sh
 # tests that have to wait for event emission on RabbitMQ node(s)
 # will do that for 1.1s
-export RABBITMQ_EVENT_PROPAGATION_INTERVAL=1100
+export GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT="5s"
 ```
 
 That will enable dependencies and reduce node's stats emission interval.

--- a/bin/ci/before_build.bat
+++ b/bin/ci/before_build.bat
@@ -29,3 +29,5 @@ call %RABBITHOLE_RABBITMQ_PLUGINS% enable rabbitmq_shovel_management
 REM Enable shovel plugin
 call %RABBITHOLE_RABBITMQ_PLUGINS% enable rabbitmq_federation
 call %RABBITHOLE_RABBITMQ_PLUGINS% enable rabbitmq_federation_management
+
+set GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT=5s

--- a/bin/ci/before_build.sh
+++ b/bin/ci/before_build.sh
@@ -33,3 +33,5 @@ $PLUGINS enable rabbitmq_shovel_management
 # Enable federation plugin
 $PLUGINS enable rabbitmq_federation
 $PLUGINS enable rabbitmq_federation_management
+
+export GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT="5s"

--- a/federation_links.go
+++ b/federation_links.go
@@ -2,12 +2,14 @@ package rabbithole
 
 import "net/url"
 
+type FederationLinkMap = []map[string]interface{}
+
 //
 // GET /api/federation-links
 //
 
 // ListFederationLinks returns a list of all federation links.
-func (c *Client) ListFederationLinks() (links []map[string]interface{}, err error) {
+func (c *Client) ListFederationLinks() (links FederationLinkMap, err error) {
 	req, err := newGETRequest(c, "federation-links")
 	if err != nil {
 		return links, err
@@ -25,7 +27,7 @@ func (c *Client) ListFederationLinks() (links []map[string]interface{}, err erro
 //
 
 // ListFederationLinksIn returns a list of federation links in a vhost.
-func (c *Client) ListFederationLinksIn(vhost string) (links []map[string]interface{}, err error) {
+func (c *Client) ListFederationLinksIn(vhost string) (links FederationLinkMap, err error) {
 	req, err := newGETRequest(c, "federation-links/"+url.PathEscape(vhost))
 	if err != nil {
 		return links, err

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
+	github.com/rabbitmq/amqp091-go v1.3.4 // indirect
 	github.com/streadway/amqp v1.0.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rabbitmq/amqp091-go v1.3.4 h1:tXuIslN1nhDqs2t6Jrz3BAoqvt4qIZzxvdbdcxWtHYU=
+github.com/rabbitmq/amqp091-go v1.3.4/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
 github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=
 github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -747,7 +747,6 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 			Ω(q.Name).Should(Equal(qn))
 			Ω(q.Node).ShouldNot(BeNil())
 			Ω(q.Durable).ShouldNot(BeNil())
-			Ω(q.Status).ShouldNot(BeEmpty())
 			Ω(qs.Page).Should(Equal(1))
 			Ω(qs.PageCount).Should(Equal(1))
 			Ω(qs.ItemCount).ShouldNot(BeNil())
@@ -836,7 +835,6 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 
 			Ω(q.Vhost).Should(Equal(vh))
 			Ω(q.Durable).Should(Equal(false))
-			Ω(q.Status).ShouldNot(BeEmpty())
 
 			_, err = rmqc.DeleteQueue(vh, qn, QueueDeleteOptions{IfEmpty: true})
 			Ω(err).Should(BeNil())

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -843,7 +843,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 		})
 	})
 
-	FContext("DELETE /queues/{vhost}/{name}", func() {
+	Context("DELETE /queues/{vhost}/{name}", func() {
 		It("deletes a queue", func() {
 			vh := "rabbit/hole"
 			conn := openConnection(vh)

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -138,6 +138,11 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 
 	Context("DELETE /api/connections/{name}", func() {
 		It("closes the connection", func() {
+			xs, _ := rmqc.ListConnections()
+			for _, c := range xs {
+				rmqc.CloseConnection(c.Name)
+			}
+
 			Eventually(func(g Gomega) []ConnectionInfo {
 				xs, err := rmqc.ListConnections()
 				Ω(err).Should(BeNil())

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -565,7 +565,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 			params.Add("lengths_age", "1800")
 			params.Add("lengths_incr", "30")
 
-			shortSleep()
+			mediumSleep()
 			Eventually(func(g Gomega) []QueueInfo {
 				xs, err := rmqc.ListQueuesWithParameters(params)
 				Ω(err).Should(BeNil())

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -2833,7 +2833,13 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 
 			_, err := rmqc.PutOperatorPolicy(vh, name, policy)
 			Ω(err).Should(BeNil())
-			awaitEventPropagation()
+
+			Eventually(func(g Gomega) string {
+				x, err := rmqc.GetOperatorPolicy(vh, name)
+				Ω(err).Should(BeNil())
+
+				return x.Name
+			}).Should(Equal(name))
 
 			resp, err := rmqc.DeleteOperatorPolicy(vh, name)
 			Ω(err).Should(BeNil())
@@ -2927,7 +2933,12 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 			Ω(err).Should(BeNil())
 			Ω(resp.Status).Should(HavePrefix("20"))
 
-			awaitEventPropagation()
+			Eventually(func(g Gomega) string {
+				x, err := rmqc.GetOperatorPolicy(vh, name)
+				Ω(err).Should(BeNil())
+
+				return x.Name
+			}).Should(Equal(name))
 
 			pol, err = rmqc.GetOperatorPolicy(vh, name)
 			Ω(err).Should(BeNil())
@@ -3120,7 +3131,12 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 				_, err := rmqc.PutFederationUpstream(vh, name, def)
 				Ω(err).Should(BeNil())
 
-				awaitEventPropagation()
+				Eventually(func(g Gomega) string {
+					x, err := rmqc.GetFederationUpstream(vh, name)
+					Ω(err).Should(BeNil())
+
+					return x.Name
+				}).Should(Equal(name))
 
 				up, err := rmqc.GetFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
@@ -3135,6 +3151,13 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 
 				_, err = rmqc.DeleteFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
+
+				Eventually(func(g Gomega) []FederationUpstream {
+					xs, err := rmqc.ListFederationUpstreamsIn(vh)
+					Ω(err).Should(BeNil())
+
+					return xs
+				}).Should(BeEmpty())
 			})
 		})
 	})
@@ -3165,7 +3188,12 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 				_, err = rmqc.PutFederationUpstream(vh, name, def)
 				Ω(err).Should(BeNil())
 
-				awaitEventPropagation()
+				Eventually(func(g Gomega) string {
+					x, err := rmqc.GetFederationUpstream(vh, name)
+					Ω(err).Should(BeNil())
+
+					return x.Name
+				}).Should(Equal(name))
 
 				up, err = rmqc.GetFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
@@ -3185,6 +3213,13 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 
 				_, err = rmqc.DeleteFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
+
+				Eventually(func(g Gomega) []FederationUpstream {
+					xs, err := rmqc.ListFederationUpstreamsIn(vh)
+					Ω(err).Should(BeNil())
+
+					return xs
+				}).Should(BeEmpty())
 			})
 		})
 
@@ -3205,7 +3240,12 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 				_, err := rmqc.PutFederationUpstream(vh, name, def)
 				Ω(err).Should(BeNil())
 
-				awaitEventPropagation()
+				Eventually(func(g Gomega) string {
+					x, err := rmqc.GetFederationUpstream(vh, name)
+					Ω(err).Should(BeNil())
+
+					return x.Name
+				}).Should(Equal(name))
 
 				up, err := rmqc.GetFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
@@ -3230,7 +3270,12 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 				_, err = rmqc.PutFederationUpstream(vh, name, def2)
 				Ω(err).Should(BeNil())
 
-				awaitEventPropagation()
+				Eventually(func(g Gomega) string {
+					x, err := rmqc.GetFederationUpstream(vh, name)
+					Ω(err).Should(BeNil())
+
+					return x.Name
+				}).Should(Equal(name))
 
 				up, err = rmqc.GetFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
@@ -3245,6 +3290,13 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 
 				_, err = rmqc.DeleteFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
+
+				Eventually(func(g Gomega) []FederationUpstream {
+					xs, err := rmqc.ListFederationUpstreamsIn(vh)
+					Ω(err).Should(BeNil())
+
+					return xs
+				}).Should(BeEmpty())
 			})
 		})
 
@@ -3288,7 +3340,12 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 				_, err := rmqc.PutFederationUpstream(vh, name, def)
 				Ω(err).Should(BeNil())
 
-				awaitEventPropagation()
+				Eventually(func(g Gomega) string {
+					x, err := rmqc.GetFederationUpstream(vh, name)
+					Ω(err).Should(BeNil())
+
+					return x.Name
+				}).Should(Equal(name))
 
 				up, err := rmqc.GetFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
@@ -3298,9 +3355,12 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 				_, err = rmqc.DeleteFederationUpstream(vh, name)
 				Ω(err).Should(BeNil())
 
-				up, err = rmqc.GetFederationUpstream(vh, name)
-				Ω(up).Should(BeNil())
-				Ω(err).Should(Equal(ErrorResponse{404, "Object Not Found", "Not Found"}))
+				Eventually(func(g Gomega) []FederationUpstream {
+					xs, err := rmqc.ListFederationUpstreamsIn(vh)
+					Ω(err).Should(BeNil())
+
+					return xs
+				}).Should(BeEmpty())
 			})
 		})
 	})
@@ -3330,7 +3390,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 				// upstream exchange: amq.topic
 				// downstream vhost: 'rabbit-hole'
 				// downstream exchange: amq.topic
-				vhost := "rabbit/hole"
+				vh := "rabbit/hole"
 
 				// create upstream
 				upstreamName := "myUpsteam"
@@ -3339,7 +3399,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 					Expires: 1800000,
 				}
 
-				_, err := rmqc.PutFederationUpstream(vhost, upstreamName, def)
+				_, err := rmqc.PutFederationUpstream(vh, upstreamName, def)
 				Ω(err).Should(BeNil())
 
 				// create policy to match upstream
@@ -3352,18 +3412,23 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 					},
 				}
 
-				_, err = rmqc.PutPolicy(vhost, policyName, policy)
+				_, err = rmqc.PutPolicy(vh, policyName, policy)
 				Ω(err).Should(BeNil())
 
-				awaitEventPropagation()
+				Eventually(func(g Gomega) FederationLinkMap {
+					xs, err := rmqc.ListFederationLinksIn(vh)
+					Ω(err).Should(BeNil())
+
+					return xs
+				}).ShouldNot(BeEmpty())
 
 				// assertions
-				list, err := rmqc.ListFederationLinksIn(vhost)
+				list, err := rmqc.ListFederationLinksIn(vh)
 				Ω(len(list)).Should(Equal(1))
 				Ω(err).Should(BeNil())
 
 				var link = list[0]
-				Ω(link["vhost"]).Should(Equal(vhost))
+				Ω(link["vhost"]).Should(Equal(vh))
 				Ω(link["upstream"]).Should(Equal(upstreamName))
 				Ω(link["type"]).Should(Equal("exchange"))
 				Ω(link["exchange"]).Should(Equal("amq.topic"))
@@ -3371,17 +3436,18 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 				Ω([]string{"running", "starting"}).Should(ContainElement(link["status"]))
 
 				// cleanup
-				_, err = rmqc.DeletePolicy(vhost, policyName)
+				_, err = rmqc.DeletePolicy(vh, policyName)
 				Ω(err).Should(BeNil())
 
-				_, err = rmqc.DeleteFederationUpstream(vhost, upstreamName)
+				_, err = rmqc.DeleteFederationUpstream(vh, upstreamName)
 				Ω(err).Should(BeNil())
 
-				awaitEventPropagation()
+				Eventually(func(g Gomega) FederationLinkMap {
+					xs, err := rmqc.ListFederationLinksIn(vh)
+					Ω(err).Should(BeNil())
 
-				list, err = rmqc.ListFederationLinksIn(vhost)
-				Ω(len(list)).Should(Equal(0))
-				Ω(err).Should(BeNil())
+					return xs
+				}).Should(BeEmpty())
 			})
 		})
 	})
@@ -3410,7 +3476,13 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 			_, err := rmqc.DeclareShovel(vh, sn, shovelDefinition)
 			Ω(err).Should(BeNil())
 
-			awaitEventPropagation()
+			Eventually(func(g Gomega) string {
+				x, err := rmqc.GetShovel(vh, sn)
+				Ω(err).Should(BeNil())
+
+				return x.Name
+			}).Should(Equal(sn))
+
 			x, err := rmqc.GetShovel(vh, sn)
 			Ω(err).Should(BeNil())
 			Ω(x.Name).Should(Equal(sn))
@@ -3430,7 +3502,6 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 
 			_, err = rmqc.DeleteShovel(vh, sn)
 			Ω(err).Should(BeNil())
-			awaitEventPropagation()
 
 			_, err = rmqc.DeleteQueue("/", "mySourceQueue")
 			Ω(err).Should(BeNil())
@@ -3438,8 +3509,11 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 			Ω(err).Should(BeNil())
 
 			x, err = rmqc.GetShovel(vh, sn)
-			Ω(x).Should(BeNil())
-			Ω(err).Should(Equal(ErrorResponse{404, "Object Not Found", "Not Found"}))
+			Eventually(func(g Gomega) error {
+				_, err := rmqc.GetShovel(vh, sn)
+
+				return err
+			}).Should(Equal(ErrorResponse{404, "Object Not Found", "Not Found"}))
 		})
 	})
 

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -2956,7 +2956,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 		})
 	})
 
-	FContext("GET /api/parameters/federation-upstream", func() {
+	Context("GET /api/parameters/federation-upstream", func() {
 		Context("when there are no upstreams", func() {
 			It("returns an empty response", func() {
 				Eventually(func(g Gomega) []FederationUpstream {

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -333,6 +333,11 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 
 	Context("GET /channels when there are active connections with open channels", func() {
 		It("returns decoded response", func() {
+			cs, _ := rmqc.ListConnections()
+			for _, c := range cs {
+				rmqc.CloseConnection(c.Name)
+			}
+
 			conn := openConnection("/")
 			defer conn.Close()
 

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -2956,7 +2956,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 		})
 	})
 
-	Context("GET /api/parameters/federation-upstream", func() {
+	FContext("GET /api/parameters/federation-upstream", func() {
 		Context("when there are no upstreams", func() {
 			It("returns an empty response", func() {
 				Eventually(func(g Gomega) []FederationUpstream {
@@ -2973,32 +2973,51 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 				def1 := FederationDefinition{
 					Uri: URISet{"amqp://server-name/%2f"},
 				}
-				_, err := rmqc.PutFederationUpstream("rabbit/hole", "upstream1", def1)
+
+				vh := "rabbit/hole"
+				name1 := "upstream1"
+				name2 := "upstream2"
+
+				Eventually(func(g Gomega) []FederationUpstream {
+					xs, err := rmqc.ListFederationUpstreams()
+					Ω(err).Should(BeNil())
+
+					return xs
+				}).Should(BeEmpty())
+
+				_, err := rmqc.PutFederationUpstream(vh, name1, def1)
 				Ω(err).Should(BeNil())
 
 				def2 := FederationDefinition{
 					Uri: URISet{"amqp://example.com/%2f"},
 				}
-				_, err = rmqc.PutFederationUpstream("/", "upstream2", def2)
+				_, err = rmqc.PutFederationUpstream("/", name2, def2)
 				Ω(err).Should(BeNil())
 
-				awaitEventPropagation()
+				Eventually(func(g Gomega) []FederationUpstream {
+					xs, err := rmqc.ListFederationUpstreams()
+					Ω(err).Should(BeNil())
+
+					return xs
+				}).ShouldNot(BeEmpty())
 
 				list, err := rmqc.ListFederationUpstreams()
 				Ω(err).Should(BeNil())
 				Ω(len(list)).Should(Equal(2))
 
-				_, err = rmqc.DeleteFederationUpstream("rabbit/hole", "upstream1")
+				_, err = rmqc.DeleteFederationUpstream(vh, name1)
 				Ω(err).Should(BeNil())
 
-				_, err = rmqc.DeleteFederationUpstream("/", "upstream2")
+				_, err = rmqc.DeleteFederationUpstream("/", name2)
 				Ω(err).Should(BeNil())
 
-				awaitEventPropagation()
+				Eventually(func(g Gomega) []FederationUpstream {
+					xs, err := rmqc.ListFederationUpstreams()
+					Ω(err).Should(BeNil())
 
-				list, err = rmqc.ListFederationUpstreams()
-				Ω(err).Should(BeNil())
-				Ω(len(list)).Should(Equal(0))
+					return xs
+				}).Should(BeEmpty())
+
 			})
 		})
 	})
@@ -3006,9 +3025,14 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 	Context("GET /api/parameters/federation-upstream/{vhost}", func() {
 		Context("when there are no upstreams", func() {
 			It("returns an empty response", func() {
-				list, err := rmqc.ListFederationUpstreamsIn("rabbit/hole")
-				Ω(err).Should(BeNil())
-				Ω(list).Should(BeEmpty())
+				vh := "rabbit/hole"
+
+				Eventually(func(g Gomega) []FederationUpstream {
+					xs, err := rmqc.ListFederationUpstreamsIn(vh)
+					Ω(err).Should(BeNil())
+
+					return xs
+				}).Should(BeEmpty())
 			})
 		})
 
@@ -3030,7 +3054,12 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 				_, err = rmqc.PutFederationUpstream(vh, "vhost-upstream2", def2)
 				Ω(err).Should(BeNil())
 
-				awaitEventPropagation()
+				Eventually(func(g Gomega) []FederationUpstream {
+					xs, err := rmqc.ListFederationUpstreamsIn(vh)
+					Ω(err).Should(BeNil())
+
+					return xs
+				}).ShouldNot(BeEmpty())
 
 				list, err := rmqc.ListFederationUpstreamsIn(vh)
 				Ω(err).Should(BeNil())
@@ -3040,7 +3069,12 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 				_, err = rmqc.DeleteFederationUpstream(vh, "vhost-upstream1")
 				Ω(err).Should(BeNil())
 
-				awaitEventPropagation()
+				Eventually(func(g Gomega) []FederationUpstream {
+					xs, err := rmqc.ListFederationUpstreamsIn(vh)
+					Ω(err).Should(BeNil())
+
+					return xs
+				}).ShouldNot(BeEmpty())
 
 				list, err = rmqc.ListFederationUpstreamsIn(vh)
 				Ω(err).Should(BeNil())
@@ -3050,11 +3084,12 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 				_, err = rmqc.DeleteFederationUpstream(vh, "vhost-upstream2")
 				Ω(err).Should(BeNil())
 
-				awaitEventPropagation()
+				Eventually(func(g Gomega) []FederationUpstream {
+					xs, err := rmqc.ListFederationUpstreamsIn(vh)
+					Ω(err).Should(BeNil())
 
-				list, err = rmqc.ListFederationUpstreamsIn(vh)
-				Ω(err).Should(BeNil())
-				Ω(len(list)).Should(Equal(0))
+					return xs
+				}).Should(BeEmpty())
 			})
 		})
 	})


### PR DESCRIPTION
It does what our event propagation sleeps do [but better](https://onsi.github.io/gomega/#eventually).

This reduces full suite runtime from about 120s to about 22s-24s (a reduction of some 80%!)