### PR TITLE
Set default async test timeout to 5s.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,6 @@ To enable the plugins:
 
 ``` shell
 ./bin/ci/before_build.sh
-# tests that have to wait for event emission on RabbitMQ node(s)
-# will do that for 1.1s
-export GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT="5s"
 ```
 
 That will enable dependencies and reduce node's stats emission interval.

--- a/rabbithole_suite_test.go
+++ b/rabbithole_suite_test.go
@@ -2,6 +2,7 @@ package rabbithole
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -9,5 +10,6 @@ import (
 
 func TestRabbitHole(t *testing.T) {
 	RegisterFailHandler(Fail)
+	SetDefaultEventuallyTimeout(5*time.Second)
 	RunSpecs(t, "Rabbithole Suite")
 }


### PR DESCRIPTION
Removes need to set an environment variable to run tests by setting the default timeout within the test suite.