### PR TITLE
Update checkout and setup-go actions to v3.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,9 @@ jobs:
         go: ["1.18", "1.19"]
     steps:
     - name: CHECKOUT
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
     - name: Print Go version


### PR DESCRIPTION
v1/v2 actions are deprecated due to outdated NodeJS version.