### PR TITLE
Avoid out of range panic when destination type is not set

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -182,7 +182,7 @@ func (c *Client) DeclareBinding(vhost string, info BindingInfo) (res *http.Respo
 		return nil, err
 	}
 
-	req, err := newRequestWithBody(c, "POST", c.newBindingPath(vhost, info), body)
+	req, err := newRequestWithBody(c, "POST", c.bindingPath(vhost, info), body)
 
 	if err != nil {
 		return nil, err
@@ -195,7 +195,7 @@ func (c *Client) DeclareBinding(vhost string, info BindingInfo) (res *http.Respo
 	return res, nil
 }
 
-func (c *Client) newBindingPath(vhost string, info BindingInfo) string {
+func (c *Client) bindingPath(vhost string, info BindingInfo) string {
 	if info.DestinationType == "queue" {
 		// /api/bindings/{vhost}/e/{exchange}/q/{queue}
 		return "bindings/" + url.PathEscape(vhost) +
@@ -214,9 +214,8 @@ func (c *Client) newBindingPath(vhost string, info BindingInfo) string {
 
 // DeleteBinding deletes an individual binding
 func (c *Client) DeleteBinding(vhost string, info BindingInfo) (res *http.Response, err error) {
-	req, err := newRequestWithBody(c, "DELETE", "bindings/"+url.PathEscape(vhost)+
-		"/e/"+url.PathEscape(info.Source)+"/"+url.PathEscape(string(info.DestinationType[0]))+
-		"/"+url.PathEscape(info.Destination)+"/"+url.PathEscape(info.PropertiesKey), nil)
+	req, err := newRequestWithBody(c, "DELETE", c.bindingPath(vhost, info) +
+		"/"+url.PathEscape(info.PropertiesKey), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Context
`info.DestinationType[0]` panics if DestinationType is empty

```
github.com/michaelklishin/rabbit-hole/v2.(*Client).DeleteBinding(0x0?, {0x14b24d8?, 0x0?}, {{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, ...}, ...})
    	/Users/clyu/workspace/rabbit-hole/bindings.go:218 +0x2ce
    github.com/michaelklishin/rabbit-hole/v2.glob..func2.49.1()
    	/Users/clyu/workspace/rabbit-hole/rabbithole_test.go:1795 +0x65
    github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0xc00068a460?)
    	/Users/clyu/go/pkg/mod/github.com/onsi/ginkgo@v1.16.5/internal/leafnodes/runner.go:113 +0xb1
    github.com/onsi/ginkgo/internal/leafnodes.(*runner).run(0x0?)
    	/Users/clyu/go/pkg/mod/github.com/onsi/ginkgo@v1.16.5/internal/leafnodes/runner.go:64 +0x125
    github.com/onsi/ginkgo/internal/leafnodes.(*ItNode).Run(0x1095560?)
    	/Users/clyu/go/pkg/mod/github.com/onsi/ginkgo@v1.16.5/internal/leafnodes/it_node.go:26 +0x7b
    github.com/onsi/ginkgo/internal/spec.(*Spec).runSample(0xc00026b590, 0xc0000eda40?, {0x14b4100, 0xc0000a2940})
```

Rename newBindingPath helper to bindingPath

Relates to a bug reported in: https://github.com/rabbitmq/messaging-topology-operator/issues/555