### PR TITLE
Support default queue type for vhost.

### DIFF
--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -1195,6 +1195,35 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 			_, err = rmqc.DeleteVhost(vh)
 			Ω(err).Should(BeNil())
 		})
+		When("A default queue type is set", func() {
+			It("creates a vhost with a default queue type", func(){
+				vh := "rabbit/hole3"
+				tags := VhostTags{"production", "eu-west-1"}
+				vs := VhostSettings{Description: "rabbit/hole3 vhost", DefaultQueueType: "quorum", Tags: tags, Tracing: false}
+				_, err := rmqc.PutVhost(vh, vs)
+				Ω(err).Should(BeNil())
+
+				shortSleep()
+				Eventually(func(g Gomega) string {
+					v, err := rmqc.GetVhost(vh)
+					Ω(err).Should(BeNil())
+
+					return v.Name
+				}).Should(Equal(vh))
+
+				x, err := rmqc.GetVhost(vh)
+				Ω(err).Should(BeNil())
+
+				Ω(x.Name).Should(BeEquivalentTo(vh))
+				Ω(x.Description).Should(BeEquivalentTo("rabbit/hole3 vhost"))
+				Ω(x.DefaultQueueType).Should(BeEquivalentTo("quorum"))
+				Ω(x.Tags).Should(Equal(tags))
+				Ω(x.Tracing).Should(Equal(false))
+
+				_, err = rmqc.DeleteVhost(vh)
+				Ω(err).Should(BeNil())
+			})
+		})
 	})
 
 	Context("DELETE /vhosts/{name}", func() {

--- a/vhosts.go
+++ b/vhosts.go
@@ -164,7 +164,7 @@ type VhostSettings struct {
 	// Virtual host tags
 	Tags VhostTags `json:"tags"`
 	// Type of queue to create in virtual host when unspecified
-	DefaultQueueType string `json:"defaultqueuetype,omitempty"`
+	DefaultQueueType string `json:"default_queue_type,omitempty"`
 	// True if tracing should be enabled.
 	Tracing bool `json:"tracing"`
 }

--- a/vhosts.go
+++ b/vhosts.go
@@ -61,6 +61,8 @@ type VhostInfo struct {
 	Description string `json:"description"`
 	// Virtual host tags
 	Tags VhostTags `json:"tags"`
+	// Type of queue to create in virtual host when unspecified
+	DefaultQueueType string `json:"default_queue_type"`
 	// True if tracing is enabled for this virtual host
 	Tracing bool `json:"tracing"`
 
@@ -161,6 +163,8 @@ type VhostSettings struct {
 	Description string `json:"description"`
 	// Virtual host tags
 	Tags VhostTags `json:"tags"`
+	// Type of queue to create in virtual host when unspecified
+	DefaultQueueType string `json:"defaultqueuetype,omitempty"`
 	// True if tracing should be enabled.
 	Tracing bool `json:"tracing"`
 }


### PR DESCRIPTION
Fixes #258, depends on https://github.com/rabbitmq/rabbitmq-server/pull/7739 to ship in `3.11.12`.