### PR TITLE
fix: handle undefined ports

### DIFF
--- a/common.go
+++ b/common.go
@@ -17,7 +17,9 @@ func (p *Port) UnmarshalJSON(b []byte) error {
 	stringValue := string(b)
 	var parsed int64
 	var err error
-	if stringValue[0] == '"' && stringValue[len(stringValue)-1] == '"' {
+	if stringValue == `"undefined"` {
+		parsed = 0
+	} else if stringValue[0] == '"' && stringValue[len(stringValue)-1] == '"' {
 		parsed, err = strconv.ParseInt(stringValue[1:len(stringValue)-1], 10, 32)
 	} else {
 		parsed, err = strconv.ParseInt(stringValue, 10, 32)

--- a/consumers.go
+++ b/consumers.go
@@ -33,7 +33,7 @@ type BriefChannelDetail struct {
 	Node           string `json:"node"`
 	Number         int    `json:"number"`
 	PeerHost       string `json:"peer_host"`
-	PeerPort       int    `json:"peer_port"`
+	PeerPort       Port   `json:"peer_port"`
 	User           string `json:"user"`
 }
 

--- a/nodes.go
+++ b/nodes.go
@@ -36,9 +36,9 @@ type ClusterLink struct {
 	Stats     ClusterLinkStats `json:"stats"`
 	Name      string           `json:"name"`
 	PeerAddr  string           `json:"peer_addr"`
-	PeerPort  uint             `json:"peer_port"`
+	PeerPort  Port             `json:"peer_port"`
 	SockAddr  string           `json:"sock_addr"`
-	SockPort  uint             `json:"sock_port"`
+	SockPort  Port             `json:"sock_port"`
 	SendBytes uint64           `json:"send_bytes"`
 	RecvBytes uint64           `json:"recv_bytes"`
 }

--- a/queues.go
+++ b/queues.go
@@ -64,7 +64,7 @@ type ChannelDetails struct {
 	Node           string `json:"node"`
 	Number         uint   `json:"number"`
 	PeerHost       string `json:"peer_host"`
-	PeerPort       uint   `json:"peer_port"`
+	PeerPort       Port   `json:"peer_port"`
 	User           string `json:"user"`
 }
 
@@ -295,7 +295,6 @@ func (c *Client) PagedListQueuesWithParameters(params url.Values) (rec PagedQueu
 	}
 
 	return rec, nil
-
 }
 
 // PagedListQueuesWithParameters lists queues with pagination in the vhost vhost.
@@ -310,7 +309,6 @@ func (c *Client) PagedListQueuesWithParametersIn(vhost string, params url.Values
 	}
 
 	return rec, nil
-
 }
 
 //
@@ -338,7 +336,6 @@ func (c *Client) ListQueuesIn(vhost string) (rec []QueueInfo, err error) {
 // GetQueue returns information about a queue.
 func (c *Client) GetQueue(vhost, queue string) (rec *DetailedQueueInfo, err error) {
 	req, err := newGETRequest(c, "queues/"+url.PathEscape(vhost)+"/"+url.PathEscape(queue))
-
 	if err != nil {
 		return nil, err
 	}

--- a/unit_test.go
+++ b/unit_test.go
@@ -45,4 +45,33 @@ var _ = Describe("Unit tests", func() {
 			Ω(us).Should(Equal(URISet([]string{"amqp://127.0.0.1:5672", "amqp://localhost:5672"})))
 		})
 	})
+
+	Context("Port marshalling", func() {
+		It("unmarshal Port when it is a number", func() {
+			var d Port
+			s := []byte("123")
+			err := d.UnmarshalJSON(s)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			Ω(d).Should(Equal(Port(123)))
+		})
+
+		It("unmarshal Port when it is a quoted string", func() {
+			var d Port
+			s := []byte("\"456\"")
+			err := d.UnmarshalJSON(s)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			Ω(d).Should(Equal(Port(456)))
+		})
+
+		It("unmarshal Port when it is a undefined", func() {
+			var d Port
+			s := []byte("\"undefined\"")
+			err := d.UnmarshalJSON(s)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			Ω(d).Should(Equal(Port(0)))
+		})
+	})
 })


### PR DESCRIPTION
This fixes #279.

There's discussion here as to whether all ports should be able to be `"undefined"`.

Or whether it should be separate for the ones known to be undefinable.

~I also got a test failure but got the same failure on main, haven't had a chance to look into it yet.~ #281