### PR TITLE
Fixes issue when serializing ChannelDetails as an empty array

### DIFF
--- a/queues.go
+++ b/queues.go
@@ -68,6 +68,17 @@ type ChannelDetails struct {
 	User           string `json:"user"`
 }
 
+// Handles special case where `ChannelDetails` is an empty array
+// See https://github.com/rabbitmq/rabbitmq-server/issues/2684
+func (c *ChannelDetails) UnmarshalJSON(data []byte) error {
+	if string(data) == "[]" {
+		*c = ChannelDetails{}
+		return nil
+	}
+	type Alias ChannelDetails
+	return json.Unmarshal(data, (*Alias)(c))
+}
+
 // QueueDetail describe queue information with a consumer
 type QueueDetail struct {
 	Name  string `json:"name"`

--- a/unit_test.go
+++ b/unit_test.go
@@ -1,6 +1,8 @@
 package rabbithole
 
 import (
+	"encoding/json"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -72,6 +74,22 @@ var _ = Describe("Unit tests", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(d).Should(Equal(Port(0)))
+		})
+	})
+	Context("ConsumerDetails marshalling", func() {
+		It("unmarshal ConsumerDetails when channel_details is an empty array", func() {
+			var d ConsumerDetail
+			s := []byte("{\"channel_details\":[]}")
+			err := json.Unmarshal(s, &d)
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(d.ChannelDetails).Should(Equal(ChannelDetails{}))
+		})
+		It("unmarshal ConsumerDetails when channel_details is an object", func() {
+			var d ConsumerDetail
+			s := []byte("{\"channel_details\":{\"name\":\"foo\"}}")
+			err := json.Unmarshal(s, &d)
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(d.ChannelDetails).Should(Equal(ChannelDetails{Name: "foo"}))
 		})
 	})
 })


### PR DESCRIPTION
Because of https://github.com/rabbitmq/rabbitmq-server/issues/2684, in all RabbitMQ versions until 3.11.8, the
`.consumer_details.channel_details` attribute for a queue could be sent as an empty array (`[]`) instead an empty object (`{}`).

This PR provides a fix to that by customizing the json serializarion of ChannelDetails.