### PR TITLE
refs #309, unmarshalling `AutoDelete: "undefined"` to `false` not `true`

### DIFF
--- a/common.go
+++ b/common.go
@@ -110,8 +110,8 @@ type AutoDelete bool
 func (d *AutoDelete) UnmarshalJSON(b []byte) error {
 	switch string(b) {
 	case "\"undefined\"":
-		// auto_delete is "undefined", map it to true
-		*d = AutoDelete(true)
+		// auto_delete is "undefined", map it to false
+		*d = AutoDelete(false)
 	case "true":
 		*d = AutoDelete(true)
 	case "false":


### PR DESCRIPTION
`exchange.auto_delete` should not be `undefined` -> now defaults to `false` when it's string `"undefined"`, not `true`.

* by default `auto_delete` is `false`
* when `undefined`, it's more likely to behave like `false`


Please see the details / origin of this change in #309 .
I could not find any explanation for the changes in #207 .

**Why?**

_Sometimes_ there are issues with deploying exchanges using topology-operator. Unfortunately, it's a bit hard to reproduce, so I did not find the real problem yet. The exchanges are unchanged, and all set to `auto_delete: false` when being created, but the diff still says that `auto_delete` changed:

<img width="438" src="https://github.com/michaelklishin/rabbit-hole/assets/1395650/57b9623b-04a2-4089-8e6b-ac4070e066d7">

---

This is a draft, and I'm not sure how to test this, since I can only un-marshall the JSON, but setting up an exchange with `undefined` would require to "exploit a bug" in rabbitmq. (You shouldn't be able to create an exchange with `auto_delete: undefined` in the first place.)

---

If this change leads to problems for lib users, they should fix the original problem -> it may lead to fixes in rabbit? idk.