### PR TITLE
Add pagination support for /api/connections

### DIFF
--- a/connections.go
+++ b/connections.go
@@ -81,6 +81,17 @@ type ConnectionInfo struct {
 	ConnectedAt uint64 `json:"connected_at,omitempty"`
 }
 
+// PagedConnectionInfo is additional context returned for paginated requests.
+type PagedConnectionInfo struct {
+	Page          int              `json:"page"`
+	PageCount     int              `json:"page_count"`
+	PageSize      int              `json:"page_size"`
+	FilteredCount int              `json:"filtered_count"`
+	ItemCount     int              `json:"item_count"`
+	TotalCount    int              `json:"total_count"`
+	Items         []ConnectionInfo `json:"items"`
+}
+
 // Connection of a specific user. This provides just enough information
 // to the monitoring tools.
 type UserConnectionInfo struct {
@@ -107,6 +118,20 @@ func (c *Client) ListConnections() (rec []ConnectionInfo, err error) {
 
 	if err = executeAndParseRequest(c, req, &rec); err != nil {
 		return []ConnectionInfo{}, err
+	}
+
+	return rec, nil
+}
+
+// PagedListConnectionsWithParameters lists queues with pagination.
+func (c *Client) PagedListConnectionsWithParameters(params url.Values) (rec PagedConnectionInfo, err error) {
+	req, err := newGETRequestWithParameters(c, "connections", params)
+	if err != nil {
+		return PagedConnectionInfo{}, err
+	}
+
+	if err = executeAndParseRequest(c, req, &rec); err != nil {
+		return PagedConnectionInfo{}, err
 	}
 
 	return rec, nil

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hjweddie/rabbit-hole
+module github.com/michaelklishin/rabbit-hole/v2
 
 require (
 	github.com/onsi/ginkgo v1.16.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/michaelklishin/rabbit-hole/v2
+module github.com/hjweddie/rabbit-hole
 
 require (
 	github.com/onsi/ginkgo v1.16.5 // indirect


### PR DESCRIPTION
In my rabbitmq production cluster, there are 8000+ connections. I find that use /api/connections without pagination to get all connection info always response timeout.
Hope that we would request /api/connections with pagination support