### PR TITLE
Update module version to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/michaelklishin/rabbit-hole/v2
+module github.com/michaelklishin/rabbit-hole/v3
 
 require (
 	github.com/onsi/ginkgo/v2 v2.21.0


### PR DESCRIPTION
The repo was tagged as 3.0.0, however, the module directive was not
updated. This makes impossible to `go get` the new major version. This
commit updates the Go module directive to match the new major version.
