### PR TITLE
Update go.mod to publish a retract version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,4 +23,7 @@ go 1.22.0
 
 toolchain go1.23.2
 
-retract v3.0.0
+retract (
+	v3.1.1 // Used to retract v3.0.0
+	v3.0.0 // Incorrect module name, do not use
+)


### PR DESCRIPTION
After merging this, simply tag (do not create a release) with 3.1.1.

After ~1m, run `go get github.com/michaelklishin/rabbit-hole/v3`, you should observe that it gets
version 3.1.0. Further validate by running:

```
go list -m -versions github.com/michaelklishin/rabbit-hole/v3
```

The current output is `github.com/michaelklishin/rabbit-hole/v3 v3.0.0 v3.1.0`. After tagging a version with the retraction,
it should print only 3.1.0.

