### PR TITLE
Create an internal exchange

### DIFF
--- a/exchanges.go
+++ b/exchanges.go
@@ -38,6 +38,7 @@ type ExchangeSettings struct {
 	Type       string                 `json:"type"`
 	Durable    bool                   `json:"durable"`
 	AutoDelete bool                   `json:"auto_delete,omitempty"`
+	Internal   bool                   `json:"internal,omitempty"`
 	Arguments  map[string]interface{} `json:"arguments,omitempty"`
 }
 

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -2360,7 +2360,37 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 			Ω(x.Name).Should(Equal(xn))
 			Ω(x.Durable).Should(Equal(false))
 			Ω(bool(x.AutoDelete)).Should(Equal(false))
+			Ω(x.Internal).Should(Equal(false))
 			Ω(x.Type).Should(Equal("fanout"))
+			Ω(x.Vhost).Should(Equal(vh))
+
+			_, err = rmqc.DeleteExchange(vh, xn)
+			Ω(err).Should(BeNil())
+		})
+	})
+
+	Context("PUT /exchanges/{vhost}/{exchange}", func() {
+		It("declares an internal exchange", func() {
+			vh := "rabbit/hole"
+			xn := "internal"
+
+			_, err := rmqc.DeclareExchange(vh, xn, ExchangeSettings{Type: "direct", Internal: true})
+			Ω(err).Should(BeNil())
+
+			Eventually(func(g Gomega) string {
+				x, err := rmqc.GetExchange(vh, xn)
+				Ω(err).Should(BeNil())
+
+				return x.Name
+			}).Should(Equal(xn))
+
+			x, err := rmqc.GetExchange(vh, xn)
+			Ω(err).Should(BeNil())
+			Ω(x.Name).Should(Equal(xn))
+			Ω(x.Durable).Should(Equal(false))
+			Ω(bool(x.AutoDelete)).Should(Equal(false))
+			Ω(x.Internal).Should(Equal(true))
+			Ω(x.Type).Should(Equal("direct"))
 			Ω(x.Vhost).Should(Equal(vh))
 
 			_, err = rmqc.DeleteExchange(vh, xn)


### PR DESCRIPTION
Hello @michaelklishin,

For the moment, it's not possible to create an exchange with the setting **internal** set.
> It's only possible to get this information from an existing exchange.

This PR is to add this feature to _rabbit-hole_ package.

Best Regards,
Richard.
