### PR TITLE
Fix default queue type 3.10

### DIFF
--- a/vhosts.go
+++ b/vhosts.go
@@ -164,13 +164,15 @@ type VhostSettings struct {
 	// Virtual host tags
 	Tags VhostTags `json:"tags"`
 	// Type of queue to create in virtual host when unspecified
-	DefaultQueueType string `json:"default_queue_type,omitempty"`
+	DefaultQueueType     string `json:"default_queue_type,omitempty"`
+	DefaultQueueType_310 string `json:"defaultqueuetype,omitempty"`
 	// True if tracing should be enabled.
 	Tracing bool `json:"tracing"`
 }
 
 // PutVhost creates or updates a virtual host.
 func (c *Client) PutVhost(vhostname string, settings VhostSettings) (res *http.Response, err error) {
+	settings.DefaultQueueType_310 = settings.DefaultQueueType // To be compliance with RabbitMQ 3.10
 	body, err := json.Marshal(settings)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Hello @michaelklishin 

I don't know if you want to keep compliance with old RabbitMQ releases but the setting "Default Queue Type" (for a vhost) doesn't work with RabbitMQ **3.10**.

RabbitMQ **3.10** was the first release with this setting. The setting name was `defaultqueuetype`. From RabbitMQ **3.11**, the setting has been renamed to `default_queue_type`.

This PR is to be able to create a virtual host with the setting "Default Queue Type" from RabbitMQ **3.10** (and not from RabbitMQ **3.11** like now).

Best Regards,
Richard.