### PR TITLE
fix typo: definitions parameters json attribute

### DIFF
--- a/definitions.go
+++ b/definitions.go
@@ -16,7 +16,7 @@ type ExportedDefinitions struct {
 	Vhosts           *[]VhostInfo              `json:"vhosts,omitempty"`
 	Permissions      *[]Permissions            `json:"permissions,omitempty"`
 	TopicPermissions *[]TopicPermissionInfo    `json:"topic_permissions,omitempty"`
-	Parameters       *[]RuntimeParameter       `json:"paramaters,omitempty"`
+	Parameters       *[]RuntimeParameter       `json:"parameters,omitempty"`
 	GlobalParameters *[]GlobalRuntimeParameter `json:"global_parameters,omitempty"`
 	Policies         *[]PolicyDefinition       `json:"policies"`
 	Queues           *[]QueueInfo              `json:"queues"`

--- a/rabbithole_test.go
+++ b/rabbithole_test.go
@@ -4110,7 +4110,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 			Ω(*defs.Users).ShouldNot(BeEmpty())
 
 			Ω(*defs.Queues).ShouldNot(BeNil())
-			Ω(defs.Parameters).Should(BeNil())
+			Ω(*defs.Parameters).ShouldNot(BeNil())
 			Ω(*defs.Policies).ShouldNot(BeNil())
 		})
 
@@ -4127,7 +4127,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
 			Ω(defs.Users).Should(BeNil())
 
 			Ω(*defs.Queues).ShouldNot(BeNil())
-			Ω(defs.Parameters).Should(BeNil())
+			Ω(*defs.Parameters).ShouldNot(BeNil())
 			Ω(*defs.Policies).ShouldNot(BeNil())
 		})
 


### PR DESCRIPTION
Use correct key for `parameters` in definitions JSON.